### PR TITLE
feat: switch to using the /oauth2 provider

### DIFF
--- a/sdk/authentication/src/androidTest/java/com/ibm/security/verifysdk/authentication/test/OAuthProviderTest.kt
+++ b/sdk/authentication/src/androidTest/java/com/ibm/security/verifysdk/authentication/test/OAuthProviderTest.kt
@@ -203,7 +203,7 @@ internal class OAuthProviderTest {
     fun authorize_codeHappyPath_shouldReturnSuccess() = runTest {
         addMockResponse(
             HttpMethod.Post,
-            "/v1.0/endpoint/default/token",
+            "/oauth2/token",
             HttpStatusCode.OK,
             defaultHeaders,
             responseAuthorizeOk
@@ -211,7 +211,7 @@ internal class OAuthProviderTest {
 
         val result =
             oAuthProvider.authorize(
-                URL("http://localhost/v1.0/endpoint/default/token"),
+                URL("http://localhost/oauth2/token"),
                 URL("https://callback"),
                 "authorizationCode",
                 "codeVerifier",
@@ -228,7 +228,7 @@ internal class OAuthProviderTest {
     fun authorize_codeVerifierIsNull_shouldReturnSuccess() = runTest {
         addMockResponse(
             HttpMethod.Post,
-            "/v1.0/endpoint/default/token",
+            "/oauth2/token",
             HttpStatusCode.OK,
             defaultHeaders,
             responseAuthorizeOk
@@ -236,7 +236,7 @@ internal class OAuthProviderTest {
 
         val result =
             oAuthProvider.authorize(
-                URL("http://localhost/v1.0/endpoint/default/token"),
+                URL("http://localhost/oauth2/token"),
                 URL("https://callback"),
                 "authorizationCode",
                 null,
@@ -256,7 +256,7 @@ internal class OAuthProviderTest {
 //        addMockResponse(200, responseAuthorizeOk)
 //        val result =
 //            oAuthProviderSecretNull.authorize(
-//                URL("http://localhost:44444/v1.0/endpoint/default/token)"),
+//                URL("http://localhost:44444/oauth2/token)"),
 //                URL("https://callback"),
 //                "authorizationCode",
 //                "codeVerifier",
@@ -281,7 +281,7 @@ internal class OAuthProviderTest {
 //        addMockResponse(500, "Server error")
 //        val result =
 //            oAuthProvider.authorize(
-//                URL("http://localhost:44444/v1.0/endpoint/default/token)"),
+//                URL("http://localhost:44444/oauth2/token)"),
 //                URL("https://callback"),
 //                "authorizationCode",
 //                "codeVerifier",
@@ -305,7 +305,7 @@ internal class OAuthProviderTest {
 //        addMockResponse(200, "")
 //        val result =
 //            oAuthProvider.authorize(
-//                URL("http://localhost:44444/v1.0/endpoint/default/token)"),
+//                URL("http://localhost:44444/oauth2/token)"),
 //                URL("https://callback"),
 //                "authorizationCode",
 //                "codeVerifier",
@@ -335,7 +335,7 @@ internal class OAuthProviderTest {
 //        addMockResponse(200, responseAuthorizeOk)
 //        val result =
 //            oAuthProvider.authorize(
-//                URL("http://localhost:44444/v1.0/endpoint/default/token)"),
+//                URL("http://localhost:44444/oauth2/token)"),
 //                "username",
 //                "password"
 //            )
@@ -359,7 +359,7 @@ internal class OAuthProviderTest {
 //        addMockResponse(200, responseAuthorizeOk)
 //        val result =
 //            oAuthProvider.authorize(
-//                URL("http://localhost:44444/v1.0/endpoint/default/token)"),
+//                URL("http://localhost:44444/oauth2/token)"),
 //                "username",
 //                "password",
 //                arrayOf("name", "age")
@@ -387,7 +387,7 @@ internal class OAuthProviderTest {
 //        addMockResponse(200, responseAuthorizeOk)
 //        val result =
 //            oAuthProviderSecretNull.authorize(
-//                URL("http://localhost:44444/v1.0/endpoint/default/token)"),
+//                URL("http://localhost:44444/oauth2/token)"),
 //                "username",
 //                "password",
 //                arrayOf("name", "age")
@@ -414,7 +414,7 @@ internal class OAuthProviderTest {
 //        addMockResponse(200, "")
 //        val result =
 //            oAuthProvider.authorize(
-//                URL("http://localhost:44444/v1.0/endpoint/default/token)"),
+//                URL("http://localhost:44444/oauth2/token)"),
 //                "username",
 //                "password"
 //            )
@@ -436,7 +436,7 @@ internal class OAuthProviderTest {
 //        addMockResponse(500, "Server error")
 //        val result =
 //            oAuthProvider.authorize(
-//                URL("http://localhost:44444/v1.0/endpoint/default/token)"),
+//                URL("http://localhost:44444/oauth2/token)"),
 //                "username",
 //                "password"
 //            )
@@ -466,7 +466,7 @@ internal class OAuthProviderTest {
 //        )
 //        val result =
 //            oAuthProvider.authorize(
-//                URL("http://localhost:44444/v1.0/endpoint/default/token)"),
+//                URL("http://localhost:44444/oauth2/token)"),
 //                "username",
 //                "password"
 //            )
@@ -508,7 +508,7 @@ internal class OAuthProviderTest {
 //        assertTrue(result.isSuccess)
 //        result.onSuccess {
 //            assertEquals(13, it.idTokenSigningAlgValuesSupported.size)
-//            assertEquals("https://sdk.verify.ibm.com/v1.0/endpoint/default/token", it.tokenEndpoint)
+//            assertEquals("https://sdk.verify.ibm.com/oauth2/token", it.tokenEndpoint)
 //        }
 //    }
 //
@@ -617,7 +617,7 @@ internal class OAuthProviderTest {
     private val responseDiscoveryOk = """
         {
            "request_parameter_supported":true,
-           "introspection_endpoint":"https://sdk.verify.ibm.com/v1.0/endpoint/default/introspect",
+           "introspection_endpoint":"https://sdk.verify.ibm.com/oauth2/introspect",
            "claims_parameter_supported":true,
            "scopes_supported":[
               "openid",
@@ -625,7 +625,7 @@ internal class OAuthProviderTest {
               "email",
               "phone"
            ],
-           "issuer":"https://sdk.verify.ibm.com/oidc/endpoint/default",
+           "issuer":"https://sdk.verify.ibm.com/oauth2",
            "id_token_encryption_enc_values_supported":[
               "none",
               "A128GCM",
@@ -635,11 +635,11 @@ internal class OAuthProviderTest {
            "userinfo_encryption_enc_values_supported":[
               "none"
            ],
-           "authorization_endpoint":"https://sdk.verify.ibm.com/v1.0/endpoint/default/authorize",
+           "authorization_endpoint":"https://sdk.verify.ibm.com/oauth2/authorize",
            "request_object_encryption_enc_values_supported":[
               "none"
            ],
-           "device_authorization_endpoint":"https://sdk.verify.ibm.com/v1.0/endpoint/default/device_authorization",
+           "device_authorization_endpoint":"https://sdk.verify.ibm.com/oauth2/device_authorization",
            "userinfo_signing_alg_values_supported":[
               "none"
            ],
@@ -674,7 +674,7 @@ internal class OAuthProviderTest {
               "fragment",
               "form_post"
            ],
-           "token_endpoint":"https://sdk.verify.ibm.com/v1.0/endpoint/default/token",
+           "token_endpoint":"https://sdk.verify.ibm.com/oauth2/token",
            "response_types_supported":[
               "code",
               "none",
@@ -685,7 +685,7 @@ internal class OAuthProviderTest {
               "code token",
               "code token id_token"
            ],
-           "user_authorization_endpoint":"https://sdk.verify.ibm.com/v1.0/endpoint/default/user_authorization",
+           "user_authorization_endpoint":"https://sdk.verify.ibm.com/oauth2/user_authorization",
            "request_uri_parameter_supported":false,
            "userinfo_encryption_alg_values_supported":[
               "none"
@@ -700,14 +700,14 @@ internal class OAuthProviderTest {
               "urn:ietf:params:oauth:grant-type:device_code",
               "policyauth"
            ],
-           "revocation_endpoint":"https://sdk.verify.ibm.com/v1.0/endpoint/default/revoke",
-           "userinfo_endpoint":"https://sdk.verify.ibm.com/v1.0/endpoint/default/userinfo",
+           "revocation_endpoint":"https://sdk.verify.ibm.com/oauth2/revoke",
+           "userinfo_endpoint":"https://sdk.verify.ibm.com/oauth2/userinfo",
            "id_token_encryption_alg_values_supported":[
               "none",
               "RSA-OAEP",
               "RSA-OAEP-256"
            ],
-           "jwks_uri":"https://sdk.verify.ibm.com/v1.0/endpoint/default/jwks",
+           "jwks_uri":"https://sdk.verify.ibm.com/oauth2/jwks",
            "subject_types_supported":[
               "public"
            ],
@@ -726,7 +726,7 @@ internal class OAuthProviderTest {
               "ES384",
               "ES512"
            ],
-           "registration_endpoint":"https://sdk.verify.ibm.com/v1.0/endpoint/default/client_registration",
+           "registration_endpoint":"https://sdk.verify.ibm.com/oauth2/client_registration",
            "request_object_signing_alg_values_supported":[
               "none"
            ],

--- a/sdk/authentication/src/androidTest/java/com/ibm/security/verifysdk/authentication/test/OIDCMetadataInfoTest.kt
+++ b/sdk/authentication/src/androidTest/java/com/ibm/security/verifysdk/authentication/test/OIDCMetadataInfoTest.kt
@@ -175,7 +175,7 @@ internal class OIDCMetadataInfoTest {
     fun constructor_withSerializer_happyPath_shouldReturnObject() {
         val oidcMetadataInfo = json.decodeFromString<OIDCMetadataInfo>(openidConfiguration)
         assertEquals(
-            "https://sdk.verify.ibm.com/v1.0/endpoint/default/authorize",
+            "https://sdk.verify.ibm.com/oauth2/authorize",
             oidcMetadataInfo.authorizationEndpoint
         )
         assertEquals(15, oidcMetadataInfo.claimsSupported.size)
@@ -183,13 +183,13 @@ internal class OIDCMetadataInfoTest {
 
     @Test
     fun getIssuer() {
-        assertEquals("https://sdk.verify.ibm.com/oidc/endpoint/default", oidcMetadata.issuer)
+        assertEquals("https://sdk.verify.ibm.com/oauth2", oidcMetadata.issuer)
     }
 
     @Test
     fun getAuthorizationEndpoint() {
         assertEquals(
-            "https://sdk.verify.ibm.com/v1.0/endpoint/default/authorize",
+            "https://sdk.verify.ibm.com/oauth2/authorize",
             oidcMetadata.authorizationEndpoint
         )
     }
@@ -197,7 +197,7 @@ internal class OIDCMetadataInfoTest {
     @Test
     fun getTokenEndpoint() {
         assertEquals(
-            "https://sdk.verify.ibm.com/v1.0/endpoint/default/token",
+            "https://sdk.verify.ibm.com/oauth2/token",
             oidcMetadata.tokenEndpoint
         )
     }
@@ -205,20 +205,20 @@ internal class OIDCMetadataInfoTest {
     @Test
     fun getUserinfoEndpoint() {
         assertEquals(
-            "https://sdk.verify.ibm.com/v1.0/endpoint/default/userinfo",
+            "https://sdk.verify.ibm.com/oauth2/userinfo",
             oidcMetadata.userinfoEndpoint
         )
     }
 
     @Test
     fun getJwksUri() {
-        assertEquals("https://sdk.verify.ibm.com/v1.0/endpoint/default/jwks", oidcMetadata.jwksUri)
+        assertEquals("https://sdk.verify.ibm.com/oauth2/jwks", oidcMetadata.jwksUri)
     }
 
     @Test
     fun getRegistrationEndpoint() {
         assertEquals(
-            "https://sdk.verify.ibm.com/v1.0/endpoint/default/client_registration",
+            "https://sdk.verify.ibm.com/oauth2/client_registration",
             oidcMetadata.registrationEndpoint
         )
     }
@@ -1142,11 +1142,11 @@ internal class OIDCMetadataInfoTest {
     }
 
 
-    // from https://sdk.verify.ibm.com/v1.0/endpoint/default/.well-known/openid-configuration
+    // from https://sdk.verify.ibm.com/oauth2/.well-known/openid-configuration
     private val openidConfiguration = """
         {
           "request_parameter_supported": true,
-          "introspection_endpoint": "https://sdk.verify.ibm.com/v1.0/endpoint/default/introspect",
+          "introspection_endpoint": "https://sdk.verify.ibm.com/oauth2/introspect",
           "claims_parameter_supported": true,
           "scopes_supported": [
             "openid",
@@ -1154,7 +1154,7 @@ internal class OIDCMetadataInfoTest {
             "email",
             "phone"
           ],
-          "issuer": "https://sdk.verify.ibm.com/oidc/endpoint/default",
+          "issuer": "https://sdk.verify.ibm.com/oauth2",
           "id_token_encryption_enc_values_supported": [
             "none",
             "A128GCM",
@@ -1164,11 +1164,11 @@ internal class OIDCMetadataInfoTest {
           "userinfo_encryption_enc_values_supported": [
             "none"
           ],
-          "authorization_endpoint": "https://sdk.verify.ibm.com/v1.0/endpoint/default/authorize",
+          "authorization_endpoint": "https://sdk.verify.ibm.com/oauth2/authorize",
           "request_object_encryption_enc_values_supported": [
             "none"
           ],
-          "device_authorization_endpoint": "https://sdk.verify.ibm.com/v1.0/endpoint/default/device_authorization",
+          "device_authorization_endpoint": "https://sdk.verify.ibm.com/oauth2/device_authorization",
           "userinfo_signing_alg_values_supported": [
             "none"
           ],
@@ -1203,7 +1203,7 @@ internal class OIDCMetadataInfoTest {
             "fragment",
             "form_post"
           ],
-          "token_endpoint": "https://sdk.verify.ibm.com/v1.0/endpoint/default/token",
+          "token_endpoint": "https://sdk.verify.ibm.com/oauth2/token",
           "response_types_supported": [
             "code",
             "none",
@@ -1214,7 +1214,7 @@ internal class OIDCMetadataInfoTest {
             "code token",
             "code token id_token"
           ],
-          "user_authorization_endpoint": "https://sdk.verify.ibm.com/v1.0/endpoint/default/user_authorization",
+          "user_authorization_endpoint": "https://sdk.verify.ibm.com/oauth2/user_authorization",
           "request_uri_parameter_supported": false,
           "userinfo_encryption_alg_values_supported": [
             "none"
@@ -1229,14 +1229,14 @@ internal class OIDCMetadataInfoTest {
             "urn:ietf:params:oauth:grant-type:device_code",
             "policyauth"
           ],
-          "revocation_endpoint": "https://sdk.verify.ibm.com/v1.0/endpoint/default/revoke",
-          "userinfo_endpoint": "https://sdk.verify.ibm.com/v1.0/endpoint/default/userinfo",
+          "revocation_endpoint": "https://sdk.verify.ibm.com/oauth2/revoke",
+          "userinfo_endpoint": "https://sdk.verify.ibm.com/oauth2/userinfo",
           "id_token_encryption_alg_values_supported": [
             "none",
             "RSA-OAEP",
             "RSA-OAEP-256"
           ],
-          "jwks_uri": "https://sdk.verify.ibm.com/v1.0/endpoint/default/jwks",
+          "jwks_uri": "https://sdk.verify.ibm.com/oauth2/jwks",
           "subject_types_supported": [
             "public"
           ],
@@ -1255,7 +1255,7 @@ internal class OIDCMetadataInfoTest {
             "ES384",
             "ES512"
           ],
-          "registration_endpoint": "https://sdk.verify.ibm.com/v1.0/endpoint/default/client_registration",
+          "registration_endpoint": "https://sdk.verify.ibm.com/oauth2/client_registration",
           "request_object_signing_alg_values_supported": [
             "none"
           ],

--- a/sdk/buildSrc/src/main/kotlin/com/ibm/security/verifysdk/plugin/VerifySdkBuildPlugin.kt
+++ b/sdk/buildSrc/src/main/kotlin/com/ibm/security/verifysdk/plugin/VerifySdkBuildPlugin.kt
@@ -49,6 +49,7 @@ class VerifySdkBuildPlugin : Plugin<Project> {
                         preferProjectModules()
                         force("com.fasterxml.woodstox:woodstox-core:6.4.0")
                         force("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.1")
+                        force("io.netty:netty-codec-http2:4.1.111.Final") // because of CVE-2023-44487 in netty-codec-http2-4.1.93.Final
                     }
                 }
 

--- a/sdk/core/build.gradle.kts
+++ b/sdk/core/build.gradle.kts
@@ -28,12 +28,6 @@ dependencies {
     implementation("androidx.core:core-ktx:1.13.1")
 }
 
-dependencies {
-}
-
-dependencies {
-}
-
 tasks {
     register("androidJavadocJar", Jar::class) {
         archiveClassifier.set("javadoc")

--- a/sdk/examples/fido2_demo/build.gradle.kts
+++ b/sdk/examples/fido2_demo/build.gradle.kts
@@ -39,6 +39,14 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    project.configurations.all {
+        resolutionStrategy {
+            failOnVersionConflict()
+            preferProjectModules()
+            force("io.netty:netty-codec-http2:4.1.111.Final") // because of CVE-2023-44487 in netty-codec-http2-4.1.93.Final
+        }
+    }
 }
 
 dependencies {

--- a/sdk/examples/mfa_demo/build.gradle.kts
+++ b/sdk/examples/mfa_demo/build.gradle.kts
@@ -39,11 +39,19 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    project.configurations.all {
+        resolutionStrategy {
+            failOnVersionConflict()
+            preferProjectModules()
+            force("io.netty:netty-codec-http2:4.1.111.Final") // because of CVE-2023-44487 in netty-codec-http2-4.1.93.Final
+        }
+    }
 }
 
 dependencies {
 
-    implementation("androidx.activity:activity:1.9.0")
+    implementation("androidx.activity:activity-ktx:1.9.0")
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 
     implementation(project(":core"))


### PR DESCRIPTION
Verify supports two OIDC providers. This change modifies the example to use the new endpoints.

NOTE: Applications created using the custom connector template will work with both endpoints. /oauth2 offers addtional capabilities that are visible in the OpenID Connect application connector.