### PR TITLE
Release 1.0.3-102

### DIFF
--- a/sdk/authentication/src/androidTest/java/com/ibm/security/verifysdk/authentication/test/OAuthProviderTest.kt
+++ b/sdk/authentication/src/androidTest/java/com/ibm/security/verifysdk/authentication/test/OAuthProviderTest.kt
@@ -612,7 +612,7 @@ internal class OAuthProviderTest {
               "email",
               "phone"
            ],
-           "issuer":"https://sdk.verify.ibm.com/oidc/endpoint/default",
+           "issuer":"https://sdk.verify.ibm.com/oauth2",
            "id_token_encryption_enc_values_supported":[
               "none",
               "A128GCM",

--- a/sdk/authentication/src/androidTest/java/com/ibm/security/verifysdk/authentication/test/OIDCMetadataInfoTest.kt
+++ b/sdk/authentication/src/androidTest/java/com/ibm/security/verifysdk/authentication/test/OIDCMetadataInfoTest.kt
@@ -183,7 +183,7 @@ internal class OIDCMetadataInfoTest {
 
     @Test
     fun getIssuer() {
-        assertEquals("https://sdk.verify.ibm.com/oidc/endpoint/default", oidcMetadata.issuer)
+        assertEquals("https://sdk.verify.ibm.com/oauth2", oidcMetadata.issuer)
     }
 
     @Test
@@ -1154,7 +1154,7 @@ internal class OIDCMetadataInfoTest {
             "email",
             "phone"
           ],
-          "issuer": "https://sdk.verify.ibm.com/oidc/endpoint/default",
+          "issuer": "https://sdk.verify.ibm.com/oauth2",
           "id_token_encryption_enc_values_supported": [
             "none",
             "A128GCM",


### PR DESCRIPTION
### What does it do?

Update the test cases to use the oauth2 path of the OIDC provider.
### Motivation and Context

This change was initially submitted in https://github.com/ibm-security-verify/verify-sdk-android/pull/14 , but got accidentally overwritten.
