### PR TITLE
Update cleanup.yaml

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -12,9 +12,6 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
-      - name: Set up GitHub CLI
-        uses: cli/cli-action@v2
-
       - name: Install jq
         run: sudo apt-get install jq
 


### PR DESCRIPTION
### What does it do?
<!--- Describe your changes in detail -->
Fixes and error in the cleanup workflow when attempt to install GitHub CLI. According to the [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows), GH CLI is preinstalled.

### Motivation and Context
Automatically cleanup workflow job log.
