### PR TITLE
Update OAuthProvider.kt

### DIFF
--- a/sdk/authentication/src/main/java/com/ibm/security/verifysdk/authentication/api/OAuthProvider.kt
+++ b/sdk/authentication/src/main/java/com/ibm/security/verifysdk/authentication/api/OAuthProvider.kt
@@ -340,7 +340,8 @@ class OAuthProvider(val clientId: String, val clientSecret: String? = null) : Ba
         url: URL,
         refreshToken: String,
         scope: Array<String>? = null,
-        httpClient: HttpClient = NetworkHelper.getInstance
+        httpClient: HttpClient = NetworkHelper.getInstance,
+        clientSecret: String? = null
     ): Result<TokenInfo> {
 
         return try {
@@ -348,6 +349,7 @@ class OAuthProvider(val clientId: String, val clientSecret: String? = null) : Ba
                 "refresh_token" to refreshToken,
                 "grant_type" to "refresh_token",
                 "scope" to (scope?.joinToString(" ") ?: ""),
+                "client_secret" to (clientSecret ?: "")
             )
 
             performRequest<TokenInfo>(
@@ -355,7 +357,7 @@ class OAuthProvider(val clientId: String, val clientSecret: String? = null) : Ba
                 method = HttpMethod.Post,
                 url = url,
                 headers = additionalHeaders,
-                contentType = ContentType.Application.Json,
+                contentType = ContentType.Application.FormUrlEncoded,
                 body = (formData + additionalParameters.toList()).formUrlEncode()
             )
         } catch (e: Throwable) {


### PR DESCRIPTION
### Summary

Key changes include:

**Enhancements to OAuth token refresh:**

* [`sdk/authentication/src/main/java/com/ibm/security/verifysdk/authentication/api/OAuthProvider.kt`](diffhunk://#diff-025f766f876b3252c88cca6cdca26b259d24fae107280b16e24b10463509f192L343-R360): Added an optional `clientSecret` parameter to the `refreshToken` method to support secure token refresh operations. Updated the request's form data to include the `client_secret` if provided.
* Changed the `contentType` for the request from `ContentType.Application.Json` to `ContentType.Application.FormUrlEncoded` to properly format the form data.

### What does it do?

1. Currently the refresh fucntion has a bug that prevents it from working due to incorrect content encoding
2. Some instances require a client secret, this has been added

### Motivation and Context

Current implementation does not work correctly
