### PR TITLE
Fix issue with SDK publication to Jitpack

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/upload-artifact@v4.3.1
         with:
           name: maven-local
-          path: ~/.m2/repository/com/ibm/security
+          path: ~/.m2/repository/com/github/ibm-security-verify
 
       - name: Publish to GitHub packages
         working-directory: ./sdk
@@ -237,7 +237,7 @@ jobs:
         uses: actions/download-artifact@v4.1.7
         with:
           name: maven-local
-          path: ~/.m2/repository/com/ibm/security
+          path: ~/.m2/repository/com/github/ibm-security-verify
 
       - name: Collect code coverage result
         uses: actions/download-artifact@v4.1.7
@@ -257,12 +257,12 @@ jobs:
       - name: Move maven files to accessible folder
         run: |
           mkdir -p ./sdk/maven 
-          mv ~/.m2/repository/com/ibm/security/verifysdk/core/${{ needs.setup_environment.outputs.VERIFY_SDK_VERSION_NAME}}/* ./sdk/maven/
-          mv ~/.m2/repository/com/ibm/security/verifysdk/fido2/${{ needs.setup_environment.outputs.VERIFY_SDK_VERSION_NAME}}/* ./sdk/maven/
-          mv ~/.m2/repository/com/ibm/security/verifysdk/adaptive/${{ needs.setup_environment.outputs.VERIFY_SDK_VERSION_NAME}}/*  ./sdk/maven/
-          mv ~/.m2/repository/com/ibm/security/verifysdk/authentication/${{ needs.setup_environment.outputs.VERIFY_SDK_VERSION_NAME}}/*  ./sdk/maven/
-          mv ~/.m2/repository/com/ibm/security/verifysdk/mfa/${{ needs.setup_environment.outputs.VERIFY_SDK_VERSION_NAME}}/*  ./sdk/maven/
-          mv ~/.m2/repository/com/ibm/security/verifysdk/dc/${{ needs.setup_environment.outputs.VERIFY_SDK_VERSION_NAME}}/*  ./sdk/maven/
+          mv ~/.m2/repository/com/github/ibm-security-verify/verify-sdk-core/${{ needs.setup_environment.outputs.VERIFY_SDK_VERSION_NAME}}/* ./sdk/maven/
+          mv ~/.m2/repository/com/github/ibm-security-verify/verify-sdk-fido2/${{ needs.setup_environment.outputs.VERIFY_SDK_VERSION_NAME}}/* ./sdk/maven/
+          mv ~/.m2/repository/com/github/ibm-security-verify/verify-sdk-adaptive/${{ needs.setup_environment.outputs.VERIFY_SDK_VERSION_NAME}}/*  ./sdk/maven/
+          mv ~/.m2/repository/com/github/ibm-security-verify/verify-sdk-authentication/${{ needs.setup_environment.outputs.VERIFY_SDK_VERSION_NAME}}/*  ./sdk/maven/
+          mv ~/.m2/repository/com/github/ibm-security-verify/verify-sdk-mfa/${{ needs.setup_environment.outputs.VERIFY_SDK_VERSION_NAME}}/*  ./sdk/maven/
+          mv ~/.m2/repository/com/github/ibm-security-verify/verify-sdk-dc/${{ needs.setup_environment.outputs.VERIFY_SDK_VERSION_NAME}}/*  ./sdk/maven/
 
       - name: Update documentation folder structure for GitHub commit
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: IBM Security Verify SDK release
+name: IBM Verify SDK release
 
 on: 
   pull_request:

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -14,8 +14,8 @@ plugins {
 }
 
 // used for release naming and in mfa SDK
-extra["versionName"] = "3.0.7"
-extra["versionCode"] = "108"
+extra["versionName"] = "3.0.8"
+extra["versionCode"] = "109"
 
 configurations.all {
     resolutionStrategy {

--- a/sdk/common-publish.gradle
+++ b/sdk/common-publish.gradle
@@ -40,12 +40,12 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
-                artifactId = project.name
-                groupId 'com.ibm.security.verifysdk'
-                version "$versionName"
+                artifactId = "verify-sdk-${project.name}"
+                groupId 'com.github.ibm-security-verify'
+                version project.version ?: "$versionName"
                 pom {
                     name = artifactId
-                    description = 'com.ibm.security.verifysdk'
+                    description = "IBM Verify ${project.name.capitalize()} SDK for Android"
                     url = 'https://github.com/ibm-security-verify/verify-sdk-android'
                     licenses {
                         license {
@@ -60,8 +60,8 @@ afterEvaluate {
                     }
                     developers {
                         developer {
-                            id = ''
-                            name = 'IBM Security'
+                            id = 'ibm-verify'
+                            name = 'IBM Verify'
                             email = 'verify@au1.ibm.com'
                         }
                     }

--- a/sdk/common-publish.gradle
+++ b/sdk/common-publish.gradle
@@ -42,7 +42,7 @@ afterEvaluate {
                 from components.release
                 artifactId = "verify-sdk-${project.name}"
                 groupId 'com.github.ibm-security-verify'
-                version project.version ?: "$versionName"
+                version "$versionName"
                 pom {
                     name = artifactId
                     description = "IBM Verify ${project.name.capitalize()} SDK for Android"


### PR DESCRIPTION
This PR updates the Maven publishing configuration for the SDK.

### What does it do?
- Updates `artifactId` and `groupId`

### Motivation and Context
- Improve usability
