### PR TITLE
Release 3.1.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -381,7 +381,10 @@ jobs:
           files: |
             ./sdk/**/build/outputs/aar/*.aar
             ./sdk/**/build/reports/*.html
-            ./sdk/maven/*.*
+            ~/.m2/repository/com/github/ibm-verify/**/*.aar
+            ~/.m2/repository/com/github/ibm-verify/**/*.pom
+            ~/.m2/repository/com/github/ibm-verify/**/*.module
+            ~/.m2/repository/com/github/ibm-verify/**/*.jar
             ./sdk/IBM-Verify-SDK_code-coverage-report.zip
 
   job_summary:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -172,10 +172,17 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
-          target: default
           arch: x86_64
-          profile: Nexus 6
-          script: ./gradlew --parallel --build-cache connectedDebugAndroidTest
+          target: google_apis
+          profile: pixel_3a
+          disable-animations: true
+          emulator-options: -no-window -no-audio -no-snapshot -no-boot-anim -gpu swiftshader_indirect
+          emulator-boot-timeout: 900
+          script: |
+            adb wait-for-device
+            adb shell getprop sys.boot_completed || true
+            adb shell getprop ro.build.version.sdk || true
+            ./gradlew --build-cache connectedDebugAndroidTest
 
       - name: Store build outputs + reports
         uses: actions/upload-artifact@v4.3.1

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/MFAAttributeInfoTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/MFAAttributeInfoTest.kt
@@ -4,9 +4,9 @@
 
 package com.ibm.security.verifysdk.mfa
 
-import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.ibm.security.verifysdk.core.helper.ContextHelper
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -18,22 +18,10 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class MFAAttributeInfoTest {
 
-    private lateinit var context: Context
-
     @Before
     fun setup() {
-        context = InstrumentationRegistry.getInstrumentation().targetContext
-        MFAAttributeInfo.init(context)
-    }
-
-    @Test
-    fun init_shouldReturnMFAAttributeInfo() {
-        // When
-        val result = MFAAttributeInfo.init(context)
-
-        // Then
-        assertNotNull(result)
-        assertEquals(MFAAttributeInfo, result)
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        ContextHelper.init(context)
     }
 
     @Test
@@ -293,7 +281,7 @@ class MFAAttributeInfoTest {
         val applicationId = attributes["applicationId"] as String
 
         // Then
-        assertEquals(context.packageName, applicationId)
+        assertEquals(ContextHelper.context.packageName, applicationId)
     }
 
     @Test
@@ -384,14 +372,14 @@ class MFAAttributeInfoTest {
     }
 
     @Test
-    fun init_multipleCallsWithSameContext_shouldReturnSameInstance() {
+    fun dictionary_multipleCallsReturnConsistentDeviceId() {
         // When
-        val result1 = MFAAttributeInfo.init(context)
-        val result2 = MFAAttributeInfo.init(context)
+        val attributes1 = MFAAttributeInfo.dictionary()
+        val attributes2 = MFAAttributeInfo.dictionary()
 
         // Then
-        assertEquals(result1, result2)
-        assertEquals(MFAAttributeInfo, result1)
-        assertEquals(MFAAttributeInfo, result2)
+        val deviceId1 = attributes1["deviceId"] as String
+        val deviceId2 = attributes2["deviceId"] as String
+        assertEquals(deviceId1, deviceId2)
     }
 }

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/RefreshTokenSerializationTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/RefreshTokenSerializationTest.kt
@@ -7,6 +7,7 @@ package com.ibm.security.verifysdk.mfa
 import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.ibm.security.verifysdk.core.helper.ContextHelper
 import com.ibm.security.verifysdk.mfa.api.CloudAuthenticatorService
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -36,7 +37,7 @@ class RefreshTokenSerializationTest {
     @Before
     fun setup() {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        MFAAttributeInfo.init(appContext)
+        ContextHelper.init(appContext)
     }
 
     @SuppressLint("DenyListedBlockingApi")

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFAAttributeInfo.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFAAttributeInfo.kt
@@ -8,18 +8,67 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.edit
+import com.ibm.security.verifysdk.core.helper.ContextHelper
 import com.scottyab.rootbeer.RootBeer
 import java.util.Locale
 import java.util.UUID
 
+/**
+ * Provides device and application attribute information for MFA operations.
+ *
+ * This singleton object collects various device, application, and security-related attributes
+ * that are used during MFA registration and authentication processes. The attributes include
+ * device identifiers, hardware capabilities, application metadata, and security status.
+ *
+ * ## Usage
+ *
+ * Before using this object, ensure that [ContextHelper] has been initialized in your
+ * application's `onCreate()` method:
+ *
+ * ```kotlin
+ * class MyApplication : Application() {
+ *     override fun onCreate() {
+ *         super.onCreate()
+ *         ContextHelper.init(this)
+ *     }
+ * }
+ * ```
+ *
+ * Then retrieve device attributes as needed:
+ *
+ * ```kotlin
+ * // Get attributes with camelCase keys
+ * val attributes = MFAAttributeInfo.dictionary()
+ *
+ * // Get attributes with snake_case keys (for API compatibility)
+ * val snakeCaseAttributes = MFAAttributeInfo.dictionary(snakeCaseKey = true)
+ * ```
+ *
+ * ## Collected Attributes
+ *
+ * The following attributes are collected:
+ * - **Device Information**: name, model, type, unique device ID
+ * - **Platform Information**: OS type, OS version, SDK version
+ * - **Application Information**: bundle ID, name, version
+ * - **Hardware Capabilities**: front camera, fingerprint sensor, face recognition
+ * - **Security Status**: root/jailbreak detection
+ *
+ * ## Device ID Persistence
+ *
+ * A unique device ID is generated on first access and persisted in SharedPreferences.
+ * This ID remains consistent across app launches unless the app data is cleared.
+ *
+ * @see ContextHelper
+ */
 object MFAAttributeInfo {
 
-    private lateinit var applicationContext: Context
-
-    fun init(context: Context): MFAAttributeInfo {
-        this.applicationContext = context
-        return this
-    }
+    /**
+     * The application context retrieved from [ContextHelper].
+     *
+     * @throws IllegalStateException if [ContextHelper] has not been initialized
+     */
+    private val applicationContext: Context
+        get() = ContextHelper.context
 
     private val name: String
         get() = Build.MODEL
@@ -87,6 +136,44 @@ object MFAAttributeInfo {
     private val frameworkVersion: String
         get() = BuildConfig.VERSION_NAME
 
+    /**
+     * Returns a dictionary of device and application attributes.
+     *
+     * This method collects all available device, application, and security attributes
+     * and returns them as a map. The keys can be formatted in either camelCase or
+     * snake_case depending on the API requirements.
+     *
+     * @param snakeCaseKey If `true`, keys are formatted in snake_case (e.g., "device_name").
+     *                     If `false` (default), keys are formatted in camelCase (e.g., "deviceName").
+     *
+     * @return A map containing the following attributes:
+     * - `applicationId` / `application_id`: The application's package name
+     * - `applicationName` / `application_name`: The application's display name
+     * - `applicationVersion` / `application_version`: The application's version name
+     * - `deviceName` / `device_name`: The device model name (e.g., "Pixel 3a")
+     * - `platformType` / `platform_type`: Always "Android"
+     * - `deviceType` / `device_type`: The device manufacturer (e.g., "Google")
+     * - `deviceId` / `device_id`: A persistent unique device identifier (UUID)
+     * - `osVersion` / `os_version`: The Android OS version (e.g., "10")
+     * - `faceSupport` / `face_support`: Boolean indicating face recognition support
+     * - `deviceInsecure` / `device_insecure`: Boolean indicating if device is rooted
+     * - `fingerprintSupport` / `fingerprint_support`: Boolean indicating fingerprint sensor support
+     * - `frontCameraSupport` / `front_camera_support`: Boolean indicating front camera availability
+     * - `verifySdkVersion` / `verify_sdk_version`: The IBM Verify SDK version
+     *
+     * @throws IllegalStateException if [ContextHelper] has not been initialized
+     *
+     * @sample
+     * ```kotlin
+     * // Get attributes with camelCase keys
+     * val attrs = MFAAttributeInfo.dictionary()
+     * val deviceId = attrs["deviceId"] as String
+     *
+     * // Get attributes with snake_case keys
+     * val snakeAttrs = MFAAttributeInfo.dictionary(snakeCaseKey = true)
+     * val deviceId = snakeAttrs["device_id"] as String
+     * ```
+     */
     fun dictionary(snakeCaseKey: Boolean = false): Map<String, Any> {
         return mapOf(
             (if (snakeCaseKey) "applicationId".toSnakeCase() else "applicationId") to applicationBundleIdentifier,

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFARegistrationController.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFARegistrationController.kt
@@ -18,6 +18,20 @@ import org.slf4j.LoggerFactory
  * It parses QR code data and initiates the registration process with either Cloud or On-Premise
  * authentication providers.
  *
+ * ## Prerequisites
+ *
+ * Before using this class, you must initialize [com.ibm.security.verifysdk.core.helper.ContextHelper]
+ * in your application's `onCreate()` method:
+ *
+ * ```kotlin
+ * class MyApplication : Application() {
+ *     override fun onCreate() {
+ *         super.onCreate()
+ *         ContextHelper.init(this)
+ *     }
+ * }
+ * ```
+ *
  * ## Usage Example
  * ```kotlin
  * // Value from QR code scan
@@ -64,6 +78,7 @@ import org.slf4j.LoggerFactory
  * @see MFARegistrationDescriptor
  * @see CloudRegistrationProvider
  * @see OnPremiseRegistrationProvider
+ * @see com.ibm.security.verifysdk.core.helper.ContextHelper
  */
 class MFARegistrationController(private var data: String) {
 
@@ -126,8 +141,6 @@ class MFARegistrationController(private var data: String) {
      *
      * @param accountName The account name associated with the service. This is typically the user's
      *                    display name or identifier.
-     * @param skipTotpEnrollment A Boolean value that when set to `true`, the TOTP (Time-based One-Time Password)
-     *                          authentication method enrollment attempt will be skipped. Default is `true`.
      * @param pushToken A token that identifies the device for push notifications. This is typically obtained
      *                  from Firebase Cloud Messaging (FCM). Pass an empty string if push notifications are
      *                  not required. Default is an empty string.

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFARegistrationDescriptor.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFARegistrationDescriptor.kt
@@ -7,23 +7,134 @@ package com.ibm.security.verifysdk.mfa
 import com.ibm.security.verifysdk.core.helper.NetworkHelper
 import io.ktor.client.HttpClient
 
+/**
+ * Defines the contract for multi-factor authentication registration providers.
+ *
+ * This interface provides the core functionality for enrolling authentication factors
+ * and finalizing the registration process. Implementations handle the specific details
+ * of communicating with either cloud-based or on-premise authentication services.
+ *
+ * @param Authenticator The type of authenticator descriptor returned upon successful registration.
+ *
+ * @see CloudRegistrationProvider
+ * @see OnPremiseRegistrationProvider
+ */
 interface MFARegistrationDescriptor<out Authenticator : MFAAuthenticatorDescriptor> {
 
+    /**
+     * The push notification token for the device.
+     *
+     * This token is typically obtained from Firebase Cloud Messaging (FCM) and is used
+     * to send push notifications for transaction verification and other MFA operations.
+     */
     var pushToken: String
+
+    /**
+     * The account name associated with this registration.
+     *
+     * This is typically the user's display name or identifier that will be shown
+     * in the authenticator application.
+     */
     var accountName: String
+
+    /**
+     * Indicates whether user authentication is required for biometric operations.
+     *
+     * When `true`, the user must authenticate (e.g., via PIN, pattern, or password)
+     * before biometric operations can be performed.
+     */
     var authenticationRequired: Boolean
+
+    /**
+     * Indicates whether biometric keys should be invalidated when new biometrics are enrolled.
+     *
+     * When `true`, adding new fingerprints or face data will invalidate existing
+     * biometric keys, requiring re-enrollment of the MFA factor.
+     */
     var invalidatedByBiometricEnrollment: Boolean
 
+    /**
+     * Indicates whether user presence verification can be enrolled.
+     *
+     * User presence verification typically requires the user to confirm their presence
+     * through a simple action like tapping a button, without requiring biometric authentication.
+     *
+     * @return `true` if user presence enrollment is available, `false` otherwise.
+     */
     val canEnrollUserPresence: Boolean
+
+    /**
+     * Indicates whether biometric verification can be enrolled.
+     *
+     * Biometric verification uses fingerprint, face recognition, or other biometric
+     * methods to authenticate the user.
+     *
+     * @return `true` if biometric enrollment is available, `false` otherwise.
+     */
     val canEnrollBiomtric: Boolean
+
+    /**
+     * The number of authentication factors available for enrollment.
+     *
+     * This count includes all factors that can still be enrolled, such as TOTP,
+     * user presence, and biometric verification.
+     *
+     * @return The count of available enrollments.
+     */
     val countOfAvailableEnrollments: Int
 
+    /**
+     * Enrolls biometric verification as an authentication factor.
+     *
+     * This method registers the device's biometric capabilities (fingerprint, face recognition)
+     * as an authentication factor. The biometric data is stored securely on the device and
+     * never transmitted to the server.
+     *
+     * @param httpClient Optional HTTP client instance for making network requests.
+     *                   Defaults to [NetworkHelper.getInstance].
+     *
+     * @throws MFARegistrationException if enrollment fails due to network errors,
+     *         invalid state, or server rejection.
+     * @throws BiometricAuthenticationException if biometric hardware is not available
+     *         or biometric enrollment fails.
+     */
     @Throws
     suspend fun enrollBiometric(httpClient: HttpClient = NetworkHelper.getInstance)
 
+    /**
+     * Enrolls user presence verification as an authentication factor.
+     *
+     * This method registers a simpler form of verification that confirms the user's
+     * presence without requiring biometric authentication. This is typically used
+     * for lower-security scenarios or as a fallback when biometrics are unavailable.
+     *
+     * @param httpClient Optional HTTP client instance for making network requests.
+     *                   Defaults to [NetworkHelper.getInstance].
+     *
+     * @throws MFARegistrationException if enrollment fails due to network errors,
+     *         invalid state, or server rejection.
+     */
     @Throws
     suspend fun enrollUserPresence(httpClient: HttpClient = NetworkHelper.getInstance)
 
+    /**
+     * Finalizes the registration process and returns the registered authenticator.
+     *
+     * This method completes the registration flow by submitting all enrolled factors
+     * to the authentication service and retrieving the final authenticator descriptor.
+     * After successful finalization, the authenticator can be used for authentication
+     * operations.
+     *
+     * @param httpClient Optional HTTP client instance for making network requests.
+     *                   Defaults to [NetworkHelper.getInstance].
+     *
+     * @return A [Result] containing either:
+     *         - Success: An [MFAAuthenticatorDescriptor] representing the registered authenticator
+     *         - Failure: An [MFARegistrationException] indicating why finalization failed
+     *
+     * @throws MFARegistrationException if finalization fails due to network errors,
+     *         incomplete enrollment, or server rejection.
+     */
     @Throws
     suspend fun finalize(httpClient: HttpClient = NetworkHelper.getInstance): Result<MFAAuthenticatorDescriptor>
 }

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProvider.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProvider.kt
@@ -57,6 +57,77 @@ import java.util.UUID
 
 /**
  * Provider for cloud-based MFA registration with IBM Verify instances or custom mobile authenticators.
+ *
+ * This class handles the registration flow for cloud-based multi-factor authentication, supporting
+ * both QR code-based registration and in-app registration flows. It manages the enrollment of
+ * various authentication factors including TOTP, user presence, and biometric verification.
+ *
+ * ## Prerequisites
+ *
+ * Before using this class, ensure that [com.ibm.security.verifysdk.core.helper.ContextHelper]
+ * has been initialized in your application's `onCreate()` method:
+ *
+ * ```kotlin
+ * class MyApplication : Application() {
+ *     override fun onCreate() {
+ *         super.onCreate()
+ *         ContextHelper.init(this)
+ *     }
+ * }
+ * ```
+ *
+ * ## QR Code Registration Flow
+ *
+ * ```kotlin
+ * // 1. Scan QR code and get JSON data
+ * val qrData = """{"code":"ABC123","details_url":"https://..."}"""
+ *
+ * // 2. Create provider instance
+ * val provider = CloudRegistrationProvider(qrData)
+ *
+ * // 3. Initiate registration
+ * val result = provider.initiate(
+ *     accountName = "John Doe",
+ *     pushToken = "fcm-token-123"
+ * )
+ *
+ * result.onSuccess {
+ *     // 4. Enroll factors
+ *     while (provider.nextEnrollment() != null) {
+ *         provider.enroll().onSuccess {
+ *             println("Factor enrolled successfully")
+ *         }
+ *     }
+ *
+ *     // 5. Finalize registration
+ *     val authenticator = provider.finalize().getOrNull()
+ * }
+ * ```
+ *
+ * ## In-App Registration Flow
+ *
+ * ```kotlin
+ * // 1. Initiate registration with access token
+ * val initData = CloudRegistrationProvider.inAppInitiate(
+ *     initiateUri = URL("https://tenant.verify.ibm.com/v1.0/authenticators/initiation"),
+ *     accessToken = "bearer-token",
+ *     clientId = "client-id-uuid",
+ *     accountName = "John Doe"
+ * )
+ *
+ * // 2. Create provider and continue with enrollment
+ * val provider = CloudRegistrationProvider(initData)
+ * provider.initiate("John Doe", "fcm-token")
+ * // ... continue with enrollment as above
+ * ```
+ *
+ * @param data The JSON string containing registration initialization data, obtained either from
+ *             a QR code scan or from [inAppInitiate].
+ *
+ * @see MFARegistrationDescriptor
+ * @see MFAAuthenticatorDescriptor
+ * @see com.ibm.security.verifysdk.core.helper.ContextHelper
+ * @see inAppInitiate
  */
 class CloudRegistrationProvider(data: String) :
     MFARegistrationDescriptor<MFAAuthenticatorDescriptor> {
@@ -458,7 +529,7 @@ class CloudRegistrationProvider(data: String) :
     private fun constructRequestBody(additionalData: String): JsonObject {
 
         val attributes =
-            MFAAttributeInfo.init(ContextHelper.context).dictionary().toMutableMap()
+            MFAAttributeInfo.dictionary().toMutableMap()
         attributes["accountName"] = this.accountName
         attributes["pushToken"] = this.pushToken
         attributes.remove("applicationName")

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorService.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorService.kt
@@ -97,8 +97,7 @@ class OnPremiseAuthenticatorService(
         return try {
             log.entering()
             val attributes =
-                MFAAttributeInfo.init(ContextHelper.context).dictionary(snakeCaseKey = true)
-                    .toMutableMap()
+                MFAAttributeInfo.dictionary(snakeCaseKey = true).toMutableMap()
             accountName?.let {
                 attributes["accountName"] = it
             }

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt
@@ -143,8 +143,7 @@ class OnPremiseRegistrationProvider(data: String) :
             }
 
             val attributes =
-                MFAAttributeInfo.init(ContextHelper.context).dictionary(snakeCaseKey = true)
-                    .toMutableMap()
+                MFAAttributeInfo.dictionary(snakeCaseKey = true).toMutableMap()
             attributes["accountName"] = this.accountName
             attributes["pushToken"] = this.pushToken
             attributes["tenant_id"] = UUID.randomUUID().toString()


### PR DESCRIPTION
## What does it do?

This release includes API improvements to the MFA module and CI/CD pipeline enhancements:

**MFA Module Refactoring:**
- Removes the `init()` method from [`MFAAttributeInfo`](sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFAAttributeInfo.kt), leveraging [`ContextHelper`](sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/ContextHelper.kt) for centralized context management
- Updates [`CloudRegistrationProvider`](sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProvider.kt), [`OnPremiseRegistrationProvider`](sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt), and [`OnPremiseAuthenticatorService`](sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorService.kt) to call `MFAAttributeInfo.dictionary()` directly
- Adds documentation to [`MFAAttributeInfo`](sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFAAttributeInfo.kt), [`MFARegistrationDescriptor`](sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFARegistrationDescriptor.kt), [`MFARegistrationController`](sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFARegistrationController.kt), and [`CloudRegistrationProvider`](sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProvider.kt)
- Updates test files to initialize `ContextHelper` instead of `MFAAttributeInfo`

**CI/CD Pipeline Improvements:**
- Enhances Android emulator configuration in [`.github/workflows/build.yaml`](.github/workflows/build.yaml:172-185) with Pixel 3a profile, Google APIs target, disabled animations, and optimized GPU settings
- Adds device readiness checks with `adb wait-for-device` and boot completion verification
- Updates GitHub release artifact paths to include all Maven repository files (`.aar`, `.pom`, `.module`, `.jar`)

## Motivation and Context

**API Simplification:** The previous implementation required explicit `MFAAttributeInfo.init(context)` calls before using MFA functionality, creating redundancy since `ContextHelper` already managed the application context. This led to unnecessary initialization boilerplate, potential initialization errors, and code duplication across registration providers. By leveraging `ContextHelper`, developers now only need to initialize it once in their Application class, simplifying the API and reducing the chance of errors. This change removes 36 lines of redundant code while adding 305 lines of comprehensive documentation.

**CI/CD Reliability:** The GitHub Actions workflow needed improved stability for connected tests and complete artifact collection. The emulator configuration was updated from Nexus 6 to Pixel 3a with optimized settings (disabled animations, better GPU acceleration, increased boot timeout) to improve test reliability and speed. Release artifact paths were enhanced to ensure all Maven repository files are included in GitHub releases, providing complete SDK distributions.