### PR TITLE
refactor(mfa): MFA service refactoring with constructor injection and token persistence

### DIFF
--- a/examples/mfa_demo/src/main/java/com/ibm/security/verifysdk/mfa/demoapp/MainActivity.kt
+++ b/examples/mfa_demo/src/main/java/com/ibm/security/verifysdk/mfa/demoapp/MainActivity.kt
@@ -64,8 +64,10 @@ import com.ibm.security.verifysdk.mfa.MFAAuthenticatorDescriptor
 import com.ibm.security.verifysdk.mfa.MFARegistrationController
 import com.ibm.security.verifysdk.mfa.MFAServiceController
 import com.ibm.security.verifysdk.mfa.MFAServiceDescriptor
+import com.ibm.security.verifysdk.mfa.PendingTransactionInfo
 import com.ibm.security.verifysdk.mfa.UserAction
 import com.ibm.security.verifysdk.mfa.completeTransaction
+import com.ibm.security.verifysdk.mfa.getCryptoObjectForTransaction
 import com.ibm.security.verifysdk.mfa.demoapp.Constants.KEY_AUTHENTICATOR
 import com.ibm.security.verifysdk.mfa.demoapp.Constants.KEY_AUTHENTICATOR_TYPE
 import com.ibm.security.verifysdk.mfa.demoapp.Constants.PREFS_NAME
@@ -109,6 +111,7 @@ class MainActivity : FragmentActivity() {
     private val log: Logger = LoggerFactory.getLogger(javaClass.name)
     private var mfaAuthenticatorDescriptor: MFAAuthenticatorDescriptor? = null
     private var mfaService: MFAServiceDescriptor? = null
+    private var currentPendingTransaction: PendingTransactionInfo? = null
     private lateinit var biometricPrompt: BiometricPrompt
     private lateinit var promptInfo: BiometricPrompt.PromptInfo
 
@@ -307,13 +310,13 @@ class MainActivity : FragmentActivity() {
 
         return when (authenticator) {
             is CloudAuthenticator -> {
-                service.currentPendingTransaction?.factorID?.let { factorId ->
+                currentPendingTransaction?.factorID?.let { factorId ->
                     authenticator.biometric?.id == factorId
                 } ?: false
             }
 
             is OnPremiseAuthenticator -> {
-                val factorTypeName = service.currentPendingTransaction?.factorType
+                val factorTypeName = currentPendingTransaction?.factorType
                 factorTypeName?.contains("face", ignoreCase = true) == true ||
                         factorTypeName?.contains("fingerprint", ignoreCase = true) == true
             }
@@ -431,14 +434,36 @@ class MainActivity : FragmentActivity() {
             try {
                 withContext(Dispatchers.IO) {
                     mfaService?.nextTransaction(transactionId)
-                        ?.onSuccess { nextTransactionInfo ->
-                            log.info("Success: $nextTransactionInfo")
-                            val message = mfaService?.currentPendingTransaction?.message
+                        ?.onSuccess { (transactions, count) ->
+                            log.info("Success: (transactions=$transactions, count=$count)")
+                            
+                            // Extract the first transaction from the list
+                            currentPendingTransaction = transactions.firstOrNull()
+                            
+                            if (currentPendingTransaction == null) {
+                                // No valid transactions (all expired or none available)
+                                val errorMsg = if (count > 0) {
+                                    "All transactions have expired ($count total)"
+                                } else {
+                                    getString(R.string.error_no_pending_transactions)
+                                }
+                                updateUiState {
+                                    copy(
+                                        transactionMessage = "",
+                                        transactionFactorType = "",
+                                        hasTransaction = false,
+                                        errorMessage = errorMsg
+                                    )
+                                }
+                                return@onSuccess
+                            }
+                            
+                            val message = currentPendingTransaction?.message
                                 ?: "No transaction message"
 
                             val factorType = when (authenticator) {
                                 is CloudAuthenticator -> {
-                                    mfaService?.currentPendingTransaction?.factorID?.let { factorId ->
+                                    currentPendingTransaction?.factorID?.let { factorId ->
                                         when {
                                             authenticator.biometric?.id == factorId -> authenticator.biometric?.displayName
                                             authenticator.userPresence?.id == factorId -> authenticator.userPresence?.displayName
@@ -448,7 +473,7 @@ class MainActivity : FragmentActivity() {
                                 }
 
                                 is OnPremiseAuthenticator -> {
-                                    mfaService?.currentPendingTransaction?.factorType ?: "Unknown"
+                                    currentPendingTransaction?.factorType ?: "Unknown"
                                 }
 
                                 else -> "Unknown"
@@ -514,7 +539,7 @@ class MainActivity : FragmentActivity() {
                 val result = withContext(Dispatchers.IO) {
                     when (authenticator) {
                         is CloudAuthenticator -> {
-                            val factorId = service.currentPendingTransaction?.factorID
+                            val factorId = currentPendingTransaction?.factorID
                             val factorType = when {
                                 authenticator.biometric?.id == factorId -> authenticator.biometric?.let {
                                     FactorType.Biometric(
@@ -531,10 +556,10 @@ class MainActivity : FragmentActivity() {
                                 else -> null
                             }
 
-                            if (factorType != null) {
-                                service.completeTransaction(userAction, factorType)
+                            if (factorType != null && currentPendingTransaction != null) {
+                                service.completeTransaction(currentPendingTransaction!!, userAction, factorType)
                                     .onSuccess {
-                                        log.info("Success: ${service.currentPendingTransaction?.message}")
+                                        log.info("Success: ${currentPendingTransaction?.message}")
                                     }
                                     .onFailure {
                                         log.error("Failure: $it")
@@ -545,7 +570,7 @@ class MainActivity : FragmentActivity() {
                         }
 
                         is OnPremiseAuthenticator -> {
-                            val currentFactorType = service.currentPendingTransaction?.factorType
+                            val currentFactorType = currentPendingTransaction?.factorType
                                 ?: return@withContext Result.failure<Unit>(
                                     IllegalStateException(getString(R.string.error_no_factor_type))
                                 )
@@ -570,10 +595,10 @@ class MainActivity : FragmentActivity() {
                                 else -> null
                             }
 
-                            if (matchingFactor != null) {
-                                service.completeTransaction(userAction, matchingFactor)
+                            if (matchingFactor != null && currentPendingTransaction != null) {
+                                service.completeTransaction(currentPendingTransaction!!, userAction, matchingFactor)
                                     .onSuccess {
-                                        log.info("Success: ${service.currentPendingTransaction?.message}")
+                                        log.info("Success: ${currentPendingTransaction?.message}")
                                     }
                                     .onFailure {
                                         log.error("Failure: $it")

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/PendingTransactionInfoTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/PendingTransactionInfoTest.kt
@@ -30,7 +30,7 @@ class PendingTransactionInfoTest {
         val factorID = UUID.randomUUID()
         val factorType = "signature"
         val dataToSign = "data123"
-        val timeStamp = Instant.fromEpochMilliseconds(System.currentTimeMillis())
+        val creationTime = Instant.fromEpochMilliseconds(System.currentTimeMillis())
         val additionalData = mapOf(
             TransactionAttribute.IPAddress to "192.168.1.1",
             TransactionAttribute.Location to "New York"
@@ -44,7 +44,7 @@ class PendingTransactionInfoTest {
             factorID = factorID,
             factorType = factorType,
             dataToSign = dataToSign,
-            timeStamp = timeStamp,
+            creationTime = creationTime,
             additionalData = additionalData
         )
 
@@ -55,7 +55,7 @@ class PendingTransactionInfoTest {
         assertEquals(factorID, transaction.factorID)
         assertEquals(factorType, transaction.factorType)
         assertEquals(dataToSign, transaction.dataToSign)
-        assertEquals(timeStamp, transaction.timeStamp)
+        assertEquals(creationTime, transaction.creationTime)
         assertEquals(additionalData, transaction.additionalData)
     }
 
@@ -70,7 +70,7 @@ class PendingTransactionInfoTest {
             factorID = UUID.randomUUID(),
             factorType = "signature",
             dataToSign = "data",
-            timeStamp = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
+            creationTime = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
             additionalData = emptyMap()
         )
 
@@ -92,7 +92,7 @@ class PendingTransactionInfoTest {
             factorID = UUID.randomUUID(),
             factorType = "signature",
             dataToSign = "data",
-            timeStamp = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
+            creationTime = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
             additionalData = emptyMap()
         )
 
@@ -120,7 +120,7 @@ class PendingTransactionInfoTest {
             factorID = UUID.randomUUID(),
             factorType = "signature",
             dataToSign = "data",
-            timeStamp = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
+            creationTime = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
             additionalData = additionalData
         )
 
@@ -146,7 +146,7 @@ class PendingTransactionInfoTest {
             factorID = UUID.randomUUID(),
             factorType = "signature",
             dataToSign = "data",
-            timeStamp = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
+            creationTime = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
             additionalData = additionalData
         )
 
@@ -158,7 +158,7 @@ class PendingTransactionInfoTest {
     fun serialization_shouldSerializeAndDeserialize() {
         // Given
         val factorID = UUID.randomUUID()
-        val timeStamp = Instant.fromEpochMilliseconds(1609459200000) // 2021-01-01 00:00:00 UTC
+        val creationTime = Instant.fromEpochMilliseconds(1609459200000) // 2021-01-01 00:00:00 UTC
         val transaction = PendingTransactionInfo(
             id = "test-id-1234",
             message = "Login request",
@@ -166,7 +166,7 @@ class PendingTransactionInfoTest {
             factorID = factorID,
             factorType = "signature",
             dataToSign = "signme",
-            timeStamp = timeStamp,
+            creationTime = creationTime,
             additionalData = mapOf(TransactionAttribute.IPAddress to "192.168.1.1")
         )
         val json = Json { prettyPrint = true }
@@ -182,7 +182,7 @@ class PendingTransactionInfoTest {
         assertEquals(transaction.factorID, deserialized.factorID)
         assertEquals(transaction.factorType, deserialized.factorType)
         assertEquals(transaction.dataToSign, deserialized.dataToSign)
-        assertEquals(transaction.timeStamp, deserialized.timeStamp)
+        assertEquals(transaction.creationTime, deserialized.creationTime)
         assertEquals(transaction.additionalData.size, deserialized.additionalData.size)
     }
 
@@ -196,7 +196,7 @@ class PendingTransactionInfoTest {
             factorID = UUID.randomUUID(),
             factorType = "signature",
             dataToSign = "data",
-            timeStamp = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
+            creationTime = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
             additionalData = mapOf(TransactionAttribute.IPAddress to "192.168.1.1")
         )
 
@@ -210,7 +210,7 @@ class PendingTransactionInfoTest {
         assertEquals(original.factorID, copy.factorID)
         assertEquals(original.factorType, copy.factorType)
         assertEquals(original.dataToSign, copy.dataToSign)
-        assertEquals(original.timeStamp, copy.timeStamp)
+        assertEquals(original.creationTime, copy.creationTime)
         assertEquals(original.additionalData, copy.additionalData)
     }
 
@@ -219,7 +219,7 @@ class PendingTransactionInfoTest {
         // Given
         val id = "test-id"
         val factorID = UUID.randomUUID()
-        val timeStamp = Instant.fromEpochMilliseconds(1609459200000)
+        val creationTime = Instant.fromEpochMilliseconds(1609459200000)
         val transaction1 = PendingTransactionInfo(
             id = id,
             message = "Test",
@@ -227,7 +227,7 @@ class PendingTransactionInfoTest {
             factorID = factorID,
             factorType = "signature",
             dataToSign = "data",
-            timeStamp = timeStamp,
+            creationTime = creationTime,
             additionalData = emptyMap()
         )
         val transaction2 = PendingTransactionInfo(
@@ -237,7 +237,7 @@ class PendingTransactionInfoTest {
             factorID = factorID,
             factorType = "signature",
             dataToSign = "data",
-            timeStamp = timeStamp,
+            creationTime = creationTime,
             additionalData = emptyMap()
         )
 
@@ -250,7 +250,7 @@ class PendingTransactionInfoTest {
         // Given
         val id = "test-id"
         val factorID = UUID.randomUUID()
-        val timeStamp = Instant.fromEpochMilliseconds(1609459200000)
+        val creationTime = Instant.fromEpochMilliseconds(1609459200000)
         val transaction1 = PendingTransactionInfo(
             id = id,
             message = "Test",
@@ -258,7 +258,7 @@ class PendingTransactionInfoTest {
             factorID = factorID,
             factorType = "signature",
             dataToSign = "data",
-            timeStamp = timeStamp,
+            creationTime = creationTime,
             additionalData = emptyMap()
         )
         val transaction2 = PendingTransactionInfo(
@@ -268,7 +268,7 @@ class PendingTransactionInfoTest {
             factorID = factorID,
             factorType = "signature",
             dataToSign = "data",
-            timeStamp = timeStamp,
+            creationTime = creationTime,
             additionalData = emptyMap()
         )
 
@@ -286,7 +286,7 @@ class PendingTransactionInfoTest {
             factorID = UUID.randomUUID(),
             factorType = "signature",
             dataToSign = "data",
-            timeStamp = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
+            creationTime = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
             additionalData = emptyMap()
         )
 
@@ -312,7 +312,7 @@ class PendingTransactionInfoTest {
             factorID = UUID.randomUUID(),
             factorType = "signature",
             dataToSign = "data",
-            timeStamp = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
+            creationTime = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
             additionalData = emptyMap()
         )
         val transaction2 = PendingTransactionInfo(
@@ -322,7 +322,7 @@ class PendingTransactionInfoTest {
             factorID = UUID.randomUUID(),
             factorType = "signature",
             dataToSign = "data",
-            timeStamp = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
+            creationTime = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
             additionalData = emptyMap()
         )
 
@@ -345,7 +345,7 @@ class PendingTransactionInfoTest {
                 factorID = UUID.randomUUID(),
                 factorType = type,
                 dataToSign = "data",
-                timeStamp = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
+                creationTime = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
                 additionalData = emptyMap()
             )
             assertEquals(type, transaction.factorType)

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/RefreshTokenSerializationTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/RefreshTokenSerializationTest.kt
@@ -68,7 +68,8 @@ class RefreshTokenSerializationTest {
             _accessToken = "test_access_token",
             _refreshUri = URL("https://example.com/v1.0/authenticators/refresh"),
             _transactionUri = URL("https://example.com/v1.0/authenticators/transactions"),
-            _authenticatorId = "test_authenticator_id"
+            _authenticatorId = "test_authenticator_id",
+            httpClient = httpClient
         )
 
         // Call refreshToken with mixed-type attributes
@@ -77,8 +78,7 @@ class RefreshTokenSerializationTest {
                 refreshToken = "test_refresh_token",
                 accountName = "test@example.com",
                 pushToken = "test_push_token",
-                additionalData = null,
-                httpClient = httpClient
+                additionalData = null
             )
 
             // Verify the result is successful

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/TransactionAttributeTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/TransactionAttributeTest.kt
@@ -21,15 +21,17 @@ class TransactionAttributeTest {
             TransactionAttribute.Image,
             TransactionAttribute.UserAgent,
             TransactionAttribute.Type,
-            TransactionAttribute.Custom
+            TransactionAttribute.Custom,
+            TransactionAttribute.Correlation,
+            TransactionAttribute.DenyReason
         )
 
         // When
-        val actualAttributes = TransactionAttribute.values().toSet()
+        val actualAttributes = TransactionAttribute.entries.toSet()
 
         // Then
         assertEquals(expectedAttributes, actualAttributes)
-        assertEquals(6, TransactionAttribute.values().size)
+        assertEquals(8, TransactionAttribute.entries.size)
     }
 
     @Test
@@ -89,7 +91,7 @@ class TransactionAttributeTest {
     @Test
     fun allAttributes_shouldHaveUniqueRawValues() {
         // Given
-        val attributes = TransactionAttribute.values()
+        val attributes = TransactionAttribute.entries.toTypedArray()
 
         // When
         val rawValues = attributes.map { it.rawValue }.toSet()
@@ -166,7 +168,6 @@ class TransactionAttributeTest {
         // Then
         assertEquals("ipAddress", attribute.rawValue)
         assertEquals("IPAddress", attribute.name)
-        assertEquals(0, attribute.ordinal)
     }
 
     @Test
@@ -227,7 +228,7 @@ class TransactionAttributeTest {
     @Test
     fun allAttributes_shouldHaveDistinctNames() {
         // Given
-        val attributes = TransactionAttribute.values()
+        val attributes = TransactionAttribute.entries.toTypedArray()
 
         // When
         val names = attributes.map { it.name }.toSet()
@@ -239,7 +240,7 @@ class TransactionAttributeTest {
     @Test
     fun allAttributes_shouldHaveDistinctOrdinals() {
         // Given
-        val attributes = TransactionAttribute.values()
+        val attributes = TransactionAttribute.entries.toTypedArray()
 
         // When
         val ordinals = attributes.map { it.ordinal }.toSet()
@@ -262,7 +263,7 @@ class TransactionAttributeTest {
     @Test
     fun whenExpression_shouldBeExhaustive() {
         // Given
-        val attributes = TransactionAttribute.values()
+        val attributes = TransactionAttribute.entries.toTypedArray()
 
         // When/Then - Verify all attributes can be handled
         for (attribute in attributes) {
@@ -273,6 +274,8 @@ class TransactionAttributeTest {
                 TransactionAttribute.UserAgent -> "ua"
                 TransactionAttribute.Type -> "type"
                 TransactionAttribute.Custom -> "custom"
+                TransactionAttribute.Correlation -> "correlation"
+                TransactionAttribute.DenyReason -> "denyReason"
             }
             assert(result.isNotEmpty())
         }

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/CloudAuthenticatorIntegrationTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/CloudAuthenticatorIntegrationTest.kt
@@ -26,6 +26,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.net.URL
+import kotlin.time.ExperimentalTime
 
 /**
  * Integration test suite based on real network traces.
@@ -40,6 +41,7 @@ import java.net.URL
  * 
  * Note: Registration and factor enrollment tests are covered in CloudRegistrationProviderTest.
  */
+@OptIn(ExperimentalTime::class)
 @RunWith(AndroidJUnit4::class)
 class CloudAuthenticatorIntegrationTest {
 
@@ -241,7 +243,6 @@ class CloudAuthenticatorIntegrationTest {
 
         // Use future timestamps to avoid expiration
         val now = kotlin.time.Clock.System.now()
-        val creationTime = now
         val expiryTime = now.plus(kotlin.time.Duration.parse("2m"))
         
         // Create mock transaction using actual PendingTransactionInfo structure
@@ -252,7 +253,7 @@ class CloudAuthenticatorIntegrationTest {
             factorID = java.util.UUID.fromString("87dbc69e-3e4a-4b33-9b89-6ecdaf3c8510"),
             factorType = "signature",
             dataToSign = "test_data_to_sign",
-            creationTime = creationTime,
+            creationTime = now,
             expiryTime = expiryTime,
             additionalData = mapOf(
                 TransactionAttribute.IPAddress to "192.168.1.100",

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/CloudAuthenticatorIntegrationTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/CloudAuthenticatorIntegrationTest.kt
@@ -1,0 +1,324 @@
+/*
+ * Copyright contributors to the IBM Verify SDK for Android project
+ */
+
+package com.ibm.security.verifysdk.mfa.api
+
+import android.annotation.SuppressLint
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.ibm.security.verifysdk.authentication.model.TokenInfo
+import com.ibm.security.verifysdk.core.helper.ContextHelper
+import com.ibm.security.verifysdk.mfa.TokenPersistenceCallback
+import com.ibm.security.verifysdk.mfa.TransactionAttribute
+import com.ibm.security.verifysdk.mfa.UserAction
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URL
+
+/**
+ * Integration test suite based on real network traces.
+ * 
+ * This test suite validates the complete MFA flow:
+ * 1. Token refresh after enrollment
+ * 2. Fetch pending transactions
+ * 3. Transaction completion
+ * 4. Transaction data parsing
+ * 
+ * All sensitive data has been sanitized while preserving the structure and flow.
+ * 
+ * Note: Registration and factor enrollment tests are covered in CloudRegistrationProviderTest.
+ */
+@RunWith(AndroidJUnit4::class)
+class CloudAuthenticatorIntegrationTest {
+
+    @Before
+    fun setup() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        ContextHelper.init(appContext)
+    }
+
+    /**
+     * Test Case 1: Token Refresh After Enrollment
+     * 
+     * Based on log lines 433-464:
+     * - POST to /v1.0/authenticators/registration?metadataInResponse=false
+     * - Uses refreshToken to get new access token
+     */
+    @SuppressLint("DenyListedBlockingApi")
+    @Test
+    fun testTokenRefreshAfterEnrollment_shouldReturnNewTokens(): Unit = runBlocking {
+        var persistedToken: TokenInfo? = null
+        val callback = object : TokenPersistenceCallback {
+            override suspend fun onTokenRefreshed(
+                authenticatorId: String,
+                newToken: TokenInfo
+            ): Result<Unit> {
+                persistedToken = newToken
+                return Result.success(Unit)
+            }
+        }
+
+        val mockEngine = MockEngine { request ->
+            when {
+                request.url.encodedPath.contains("/registration") -> {
+                    respond(
+                        content = """
+                        {
+                          "expiresIn": 3600,
+                          "id": "test-authenticator-id",
+                          "accessToken": "new_access_token_after_enrollment",
+                          "version": {
+                            "number": "1.0.0",
+                            "platform": "com.ibm.security.access.verify"
+                          },
+                          "refreshToken": "new_refresh_token_after_enrollment"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine)
+        val service = CloudAuthenticatorService(
+            _accessToken = "old_access_token",
+            _refreshUri = URL("https://sdk.verify.ibm.com/v1.0/authenticators/registration"),
+            _transactionUri = URL("https://sdk.verify.ibm.com/v1.0/authenticators/transactions"),
+            _authenticatorId = "test-authenticator-id",
+            httpClient = httpClient,
+            persistenceCallback = callback
+        )
+
+        val result = service.refreshToken(
+            refreshToken = "old_refresh_token",
+            accountName = "test@example.com",
+            pushToken = "test_push_token",
+            additionalData = null
+        )
+
+        assertTrue("Token refresh should succeed", result.isSuccess)
+        result.onSuccess { newToken ->
+            assertEquals("new_access_token_after_enrollment", newToken.accessToken)
+            assertEquals("new_refresh_token_after_enrollment", newToken.refreshToken)
+            assertEquals(3600, newToken.expiresIn)
+        }
+
+        assertNotNull("Token should be persisted", persistedToken)
+        assertEquals("new_access_token_after_enrollment", persistedToken?.accessToken)
+
+        httpClient.close()
+    }
+
+    /**
+     * Test Case 2: Fetch Pending Transaction
+     * 
+     * Based on log lines 492-529:
+     * - GET to /v1.0/authenticators/{id}/verifications with state="PENDING"
+     * - Response includes transaction data with message, IP, user agent
+     */
+    @SuppressLint("DenyListedBlockingApi")
+    @Test
+    fun testFetchPendingTransaction_shouldReturnTransactionList(): Unit = runBlocking {
+        // Use future timestamps to avoid expiration (ISO-8601 format for kotlinx.serialization)
+        val now = kotlin.time.Clock.System.now()
+        val creationTime = now.toString()
+        val expiryTime = now.plus(kotlin.time.Duration.parse("2m")).toString()
+        
+        val mockEngine = MockEngine { request ->
+            when {
+                request.url.encodedPath.contains("/verifications") -> {
+                    respond(
+                        content = """
+                        {
+                          "total": 1,
+                          "verifications": [{
+                            "id": "test-transaction-id-001",
+                            "creationTime": "$creationTime",
+                            "expiryTime": "$expiryTime",
+                            "transactionData": "{\"message\":\"Verify your test configuration\",\"originIpAddress\":\"192.168.1.100\",\"originUserAgent\":\"Mozilla/5.0 (Test Browser)\"}",
+                            "authenticationMethods": [{
+                              "id": "87dbc69e-3e4a-4b33-9b89-6ecdaf3c8510",
+                              "methodType": "signature",
+                              "subType": "user_presence"
+                            }]
+                          }]
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(
+                            HttpHeaders.ContentType to listOf("application/json"),
+                            HttpHeaders.CacheControl to listOf("no-cache, no-store, max-age=0, must-revalidate")
+                        )
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine)
+        val service = CloudAuthenticatorService(
+            _accessToken = "test_access_token",
+            _refreshUri = URL("https://sdk.verify.ibm.com/v1.0/authenticators/refresh"),
+            _transactionUri = URL("https://sdk.verify.ibm.com/v1.0/authenticators/test-authenticator-id/verifications"),
+            _authenticatorId = "test-authenticator-id",
+            httpClient = httpClient
+        )
+
+        val result = service.nextTransaction()
+
+        result.onFailure { error ->
+            throw AssertionError("Fetch pending transaction failed: ${error.message}", error)
+        }
+        
+        assertTrue("Fetch pending transaction should succeed", result.isSuccess)
+        result.onSuccess { (transactions, count) ->
+            assertEquals(1, count)
+            assertEquals(1, transactions.size)
+            
+            val transaction = transactions.first()
+            assertEquals("test-transaction-id-001", transaction.id)
+            assertEquals("Verify your test configuration", transaction.message)
+            
+            // Verify transaction attributes
+            val attributes = transaction.additionalData
+            assertNotNull("Transaction attributes should not be null", attributes)
+            assertTrue("Should contain IP address", attributes.containsKey(TransactionAttribute.IPAddress))
+            assertTrue("Should contain user agent", attributes.containsKey(TransactionAttribute.UserAgent))
+        }
+
+        httpClient.close()
+    }
+
+    /**
+     * Test Case 3: Complete Transaction with Signed Data
+     * 
+     * Based on log lines 535-566:
+     * - POST to /v1.0/authenticators/{id}/verifications/{transactionId}
+     * - Includes signed data and userAction=VERIFY_ATTEMPT
+     * - Response is 204 No Content on success
+     */
+    @SuppressLint("DenyListedBlockingApi")
+    @Test
+    fun testCompleteTransaction_shouldReturn204(): Unit = runBlocking {
+        val mockEngine = MockEngine { request ->
+            when {
+                request.url.encodedPath.contains("/verifications/test-transaction-id-001") -> {
+                    respond(
+                        content = "",
+                        status = HttpStatusCode.NoContent,
+                        headers = headersOf(
+                            HttpHeaders.ContentLanguage, "en"
+                        )
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine)
+        val service = CloudAuthenticatorService(
+            _accessToken = "test_access_token",
+            _refreshUri = URL("https://sdk.verify.ibm.com/v1.0/authenticators/refresh"),
+            _transactionUri = URL("https://sdk.verify.ibm.com/v1.0/authenticators/test-authenticator-id/verifications"),
+            _authenticatorId = "test-authenticator-id",
+            httpClient = httpClient
+        )
+
+        // Use future timestamps to avoid expiration
+        val now = kotlin.time.Clock.System.now()
+        val creationTime = now
+        val expiryTime = now.plus(kotlin.time.Duration.parse("2m"))
+        
+        // Create mock transaction using actual PendingTransactionInfo structure
+        val mockTransaction = com.ibm.security.verifysdk.mfa.PendingTransactionInfo(
+            id = "test-transaction-id-001",
+            message = "Verify your test configuration",
+            postbackUri = URL("https://sdk.verify.ibm.com/v1.0/authenticators/test-auth-id/verifications/test-transaction-id-001"),
+            factorID = java.util.UUID.fromString("87dbc69e-3e4a-4b33-9b89-6ecdaf3c8510"),
+            factorType = "signature",
+            dataToSign = "test_data_to_sign",
+            creationTime = creationTime,
+            expiryTime = expiryTime,
+            additionalData = mapOf(
+                TransactionAttribute.IPAddress to "192.168.1.100",
+                TransactionAttribute.UserAgent to "Mozilla/5.0"
+            )
+        )
+
+        val result = service.completeTransaction(
+            transaction = mockTransaction,
+            userAction = UserAction.VERIFY,
+            signedData = "test_signed_data_sanitized"
+        )
+
+        result.onFailure { error ->
+            throw AssertionError("Complete transaction failed: ${error.message}", error)
+        }
+        
+        assertTrue("Complete transaction should succeed", result.isSuccess)
+
+        httpClient.close()
+    }
+
+    /**
+     * Test Case 4: Empty Transaction List
+     * 
+     * Validates handling when no pending transactions exist.
+     */
+    @SuppressLint("DenyListedBlockingApi")
+    @Test
+    fun testFetchPendingTransaction_whenNoPending_shouldReturnEmptyList(): Unit = runBlocking {
+        val mockEngine = MockEngine { request ->
+            when {
+                request.url.encodedPath.contains("/verifications") -> {
+                    respond(
+                        content = """
+                        {
+                          "total": 0,
+                          "count": 0,
+                          "verifications": []
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine)
+        val service = CloudAuthenticatorService(
+            _accessToken = "test_access_token",
+            _refreshUri = URL("https://sdk.verify.ibm.com/v1.0/authenticators/refresh"),
+            _transactionUri = URL("https://sdk.verify.ibm.com/v1.0/authenticators/test-authenticator-id/verifications"),
+            _authenticatorId = "test-authenticator-id",
+            httpClient = httpClient
+        )
+
+        val result = service.nextTransaction()
+
+        assertTrue("Fetch should succeed even with no transactions", result.isSuccess)
+        result.onSuccess { (transactions, count) ->
+            assertTrue("Transaction list should be empty", transactions.isEmpty())
+            assertEquals(0, count)
+        }
+
+        httpClient.close()
+    }
+}

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/CloudAuthenticatorServiceTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/CloudAuthenticatorServiceTest.kt
@@ -1,0 +1,259 @@
+/*
+ * Copyright contributors to the IBM Verify SDK for Android project
+ */
+
+package com.ibm.security.verifysdk.mfa.api
+
+import android.annotation.SuppressLint
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.ibm.security.verifysdk.authentication.model.TokenInfo
+import com.ibm.security.verifysdk.core.helper.ContextHelper
+import com.ibm.security.verifysdk.mfa.TokenPersistenceCallback
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URL
+
+/**
+ * Test suite for CloudAuthenticatorService to verify:
+ * 1. HttpClient constructor injection
+ * 2. Token persistence callback (blocking)
+ * 3. Immutable service design
+ */
+@RunWith(AndroidJUnit4::class)
+class CloudAuthenticatorServiceTest {
+
+    @Before
+    fun setup() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        ContextHelper.init(appContext)
+    }
+
+    @SuppressLint("DenyListedBlockingApi")
+    @Test
+    fun testHttpClientConstructorInjection() {
+        // Verify that httpClient is passed via constructor, not method parameter
+        val mockEngine = MockEngine { request ->
+            respond(
+                content = """{"access_token":"new_token","refresh_token":"new_refresh","token_type":"Bearer","expires_in":3600}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+
+        val httpClient = HttpClient(mockEngine)
+
+        // HttpClient is now a constructor parameter
+        val service = CloudAuthenticatorService(
+            _accessToken = "test_access_token",
+            _refreshUri = URL("https://example.com/v1.0/authenticators/refresh"),
+            _transactionUri = URL("https://example.com/v1.0/authenticators/transactions"),
+            _authenticatorId = "test_authenticator_id",
+            httpClient = httpClient  // Constructor parameter
+        )
+
+        runBlocking {
+            // refreshToken no longer takes httpClient as parameter
+            val result = service.refreshToken(
+                refreshToken = "test_refresh_token",
+                accountName = "test@example.com",
+                pushToken = "test_push_token",
+                additionalData = null
+            )
+
+            assertTrue("refreshToken should succeed", result.isSuccess)
+        }
+
+        httpClient.close()
+    }
+
+    @SuppressLint("DenyListedBlockingApi")
+    @Test
+    fun testTokenPersistenceCallbackBlocking() {
+        // Verify that token persistence callback is invoked and blocks
+        var callbackInvoked = false
+        var persistedToken: TokenInfo? = null
+
+        val callback = object : TokenPersistenceCallback {
+            override suspend fun onTokenRefreshed(
+                authenticatorId: String,
+                newToken: TokenInfo
+            ): Result<Unit> {
+                callbackInvoked = true
+                persistedToken = newToken
+                assertEquals("test_authenticator_id", authenticatorId)
+                return Result.success(Unit)
+            }
+        }
+
+        val mockEngine = MockEngine { request ->
+            respond(
+                content = """{"access_token":"persisted_token","refresh_token":"persisted_refresh","token_type":"Bearer","expires_in":3600}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+
+        val httpClient = HttpClient(mockEngine)
+
+        val service = CloudAuthenticatorService(
+            _accessToken = "test_access_token",
+            _refreshUri = URL("https://example.com/v1.0/authenticators/refresh"),
+            _transactionUri = URL("https://example.com/v1.0/authenticators/transactions"),
+            _authenticatorId = "test_authenticator_id",
+            httpClient = httpClient,
+            persistenceCallback = callback
+        )
+
+        runBlocking {
+            val result = service.refreshToken(
+                refreshToken = "test_refresh_token",
+                accountName = "test@example.com",
+                pushToken = "test_push_token",
+                additionalData = null
+            )
+
+            assertTrue("refreshToken should succeed", result.isSuccess)
+            assertTrue("Callback should be invoked", callbackInvoked)
+            assertEquals("persisted_token", persistedToken?.accessToken)
+            assertEquals("persisted_refresh", persistedToken?.refreshToken)
+        }
+
+        httpClient.close()
+    }
+
+    @SuppressLint("DenyListedBlockingApi")
+    @Test
+    fun testTokenPersistenceFailureCausesRefreshFailure() {
+        // Verify that if persistence fails, the entire refresh fails
+        val callback = object : TokenPersistenceCallback {
+            override suspend fun onTokenRefreshed(
+                authenticatorId: String,
+                newToken: TokenInfo
+            ): Result<Unit> {
+                // Simulate persistence failure
+                return Result.failure(Exception("Database write failed"))
+            }
+        }
+
+        val mockEngine = MockEngine { request ->
+            respond(
+                content = """{"access_token":"new_token","refresh_token":"new_refresh","token_type":"Bearer","expires_in":3600}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+
+        val httpClient = HttpClient(mockEngine)
+
+        val service = CloudAuthenticatorService(
+            _accessToken = "test_access_token",
+            _refreshUri = URL("https://example.com/v1.0/authenticators/refresh"),
+            _transactionUri = URL("https://example.com/v1.0/authenticators/transactions"),
+            _authenticatorId = "test_authenticator_id",
+            httpClient = httpClient,
+            persistenceCallback = callback
+        )
+
+        runBlocking {
+            val result = service.refreshToken(
+                refreshToken = "test_refresh_token",
+                accountName = "test@example.com",
+                pushToken = "test_push_token",
+                additionalData = null
+            )
+
+            // Refresh should fail because persistence failed
+            assertTrue("refreshToken should fail when persistence fails", result.isFailure)
+            result.onFailure { error ->
+                assertTrue(
+                    "Error message should mention persistence failure",
+                    error.message?.contains("persistence failed") == true
+                )
+            }
+        }
+
+        httpClient.close()
+    }
+
+    @SuppressLint("DenyListedBlockingApi")
+    @Test
+    fun testImmutableServiceDesign() {
+        // Verify that service properties are immutable
+        val mockEngine = MockEngine { request ->
+            respond(
+                content = """{"access_token":"new_token","refresh_token":"new_refresh","token_type":"Bearer","expires_in":3600}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+
+        val httpClient = HttpClient(mockEngine)
+
+        val service = CloudAuthenticatorService(
+            _accessToken = "original_token",
+            _refreshUri = URL("https://example.com/v1.0/authenticators/refresh"),
+            _transactionUri = URL("https://example.com/v1.0/authenticators/transactions"),
+            _authenticatorId = "test_authenticator_id",
+            httpClient = httpClient
+        )
+
+        // Access token should remain unchanged after refresh
+        val originalToken = service.accessToken
+        assertEquals("original_token", originalToken)
+
+        runBlocking {
+            service.refreshToken(
+                refreshToken = "test_refresh_token",
+                accountName = "test@example.com",
+                pushToken = "test_push_token",
+                additionalData = null
+            )
+
+            // Service instance still has original token (immutable)
+            assertEquals("original_token", service.accessToken)
+        }
+
+        httpClient.close()
+    }
+
+    @Test
+    fun testServicePropertiesAreAccessible() {
+        // Verify that all service properties are accessible
+        val mockEngine = MockEngine { request ->
+            respond(
+                content = "{}",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+
+        val httpClient = HttpClient(mockEngine)
+
+        val service = CloudAuthenticatorService(
+            _accessToken = "test_token",
+            _refreshUri = URL("https://example.com/refresh"),
+            _transactionUri = URL("https://example.com/transactions"),
+            _authenticatorId = "test_id",
+            httpClient = httpClient
+        )
+
+        assertEquals("test_token", service.accessToken)
+        assertEquals("https://example.com/refresh", service.refreshUri.toString())
+        assertEquals("https://example.com/transactions", service.transactionUri.toString())
+        assertEquals("test_id", service.authenticatorId)
+
+        httpClient.close()
+    }
+}
+

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/model/cloud/TransactionResultTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/model/cloud/TransactionResultTest.kt
@@ -409,6 +409,146 @@ class TransactionResultTest {
         assert(result.contains("type"))
         assert(result.contains("subType"))
     }
+
+    // Tests for optional fields (correlationEnabled, correlationValue, expiryTime)
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun verificationInfo_withCorrelationFields_shouldSetValues() {
+        // Given
+        val expiryTime = Instant.fromEpochMilliseconds(1640005000000)
+        
+        // When
+        val verification = TransactionResult.VerificationInfo(
+            id = "43fd907a-5ca0-416b-80b6-ec1d42b0ebf8",
+            creationTime = testCreationTime,
+            expiryTime = expiryTime,
+            correlationEnabled = true,
+            correlationValue = "42",
+            transactionInfo = testTransactionInfo,
+            methodInfo = listOf(testMethodInfo)
+        )
+
+        // Then
+        assertEquals(true, verification.correlationEnabled)
+        assertEquals("42", verification.correlationValue)
+        assertEquals(expiryTime, verification.expiryTime)
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun verificationInfo_withoutOptionalFields_shouldUseDefaults() {
+        // When
+        val verification = TransactionResult.VerificationInfo(
+            id = "test-id",
+            creationTime = testCreationTime,
+            transactionInfo = testTransactionInfo,
+            methodInfo = listOf(testMethodInfo)
+        )
+
+        // Then
+        assertEquals(false, verification.correlationEnabled)
+        assertEquals(null, verification.correlationValue)
+        assertEquals(null, verification.expiryTime)
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun verificationInfo_deserialization_withCorrelationData_shouldParseCorrectly() {
+        // Given - Based on anonymized sample payload
+        val jsonString = """
+            {
+                "id": "43fd907a-5ca0-416b-80b6-ec1d42b0ebf8",
+                "creationTime": "2026-03-08T12:41:07.514Z",
+                "expiryTime": "2026-03-08T13:41:07.514Z",
+                "correlationEnabled": true,
+                "correlationValue": "42",
+                "transactionData": "{\"message\":\"Verify your configuration\"}",
+                "authenticationMethods": [
+                    {
+                        "methodType": "signature",
+                        "subType": "userPresence",
+                        "id": "730a5147-24fd-4dc0-8c08-7ebecdbff5fe"
+                    }
+                ]
+            }
+        """.trimIndent()
+        val json = Json { ignoreUnknownKeys = true }
+
+        // When
+        val verification = json.decodeFromString<TransactionResult.VerificationInfo>(jsonString)
+
+        // Then
+        assertEquals("43fd907a-5ca0-416b-80b6-ec1d42b0ebf8", verification.id)
+        assertEquals(true, verification.correlationEnabled)
+        assertEquals("42", verification.correlationValue)
+        assertNotNull(verification.expiryTime)
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun verificationInfo_deserialization_withoutCorrelationValue_shouldUseNull() {
+        // Given
+        val jsonString = """
+            {
+                "id": "test-id",
+                "creationTime": "2026-03-08T12:41:07.514Z",
+                "correlationEnabled": true,
+                "transactionData": "{}",
+                "authenticationMethods": []
+            }
+        """.trimIndent()
+        val json = Json { ignoreUnknownKeys = true }
+
+        // When
+        val verification = json.decodeFromString<TransactionResult.VerificationInfo>(jsonString)
+
+        // Then
+        assertEquals(true, verification.correlationEnabled)
+        assertEquals(null, verification.correlationValue)
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun verificationInfo_deserialization_withoutExpiryTime_shouldUseNull() {
+        // Given
+        val jsonString = """
+            {
+                "id": "test-id",
+                "creationTime": "2026-03-08T12:41:07.514Z",
+                "transactionData": "{}",
+                "authenticationMethods": []
+            }
+        """.trimIndent()
+        val json = Json { ignoreUnknownKeys = true }
+
+        // When
+        val verification = json.decodeFromString<TransactionResult.VerificationInfo>(jsonString)
+// Then
+assertEquals(null, verification.expiryTime)
 }
+
+@OptIn(ExperimentalTime::class)
+@Test
+fun verificationInfo_deserialization_withoutCorrelationEnabled_shouldUseDefaults() {
+// Given - Test case: without correlationEnabled, no correlationValue
+val jsonString = """
+    {
+        "id": "test-id-no-correlation",
+        "creationTime": "2026-03-08T12:41:07.514Z",
+        "transactionData": "{}",
+        "authenticationMethods": []
+    }
+""".trimIndent()
+val json = Json { ignoreUnknownKeys = true }
+
+// When
+val verification = json.decodeFromString<TransactionResult.VerificationInfo>(jsonString)
+
+// Then
+assertEquals(false, verification.correlationEnabled)
+assertEquals(null, verification.correlationValue)
+}
+}
+
 
 

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/model/onprem/TransactionResultTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/model/onprem/TransactionResultTest.kt
@@ -7,6 +7,8 @@ package com.ibm.security.verifysdk.mfa.model.onprem
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
@@ -477,6 +479,154 @@ class TransactionResultTest {
         assertNotNull(attribute.values)
         assertNotNull(attribute.uri)
         assertNotNull(attribute.transactionId)
+    }
+
+    // Tests for mmfa:request:extras attribute with correlation and denyReason
+    @Test
+    fun attributeInfo_withCorrelationEnabledTrue_andCorrelationValue_shouldParseCorrectly() {
+        // Given - Based on anonymized sample payload with correlationEnabled as boolean
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{\"correlationValue\":\"84\",\"correlationEnabled\":true,\"denyReasonEnabled\":true}"),
+            uri = "mmfa:request:extras",
+            transactionId = "b400d358-2410-48c3-984b-02afa2110844"
+        )
+
+        // When
+        val jsonString = attribute.values.first()
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(jsonString).jsonObject
+
+        // Then
+        assertNotNull(jsonElement["correlationEnabled"])
+        assertNotNull(jsonElement["correlationValue"])
+        assertNotNull(jsonElement["denyReasonEnabled"])
+        assertEquals("84", jsonElement["correlationValue"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun attributeInfo_withCorrelationEnabledAsString_shouldParseCorrectly() {
+        // Given - Test correlationEnabled as string "true"
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{\"correlationValue\":\"42\",\"correlationEnabled\":\"true\",\"denyReasonEnabled\":\"false\"}"),
+            uri = "mmfa:request:extras",
+            transactionId = "test-transaction-id"
+        )
+
+        // When
+        val jsonString = attribute.values.first()
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(jsonString).jsonObject
+
+        // Then
+        assertNotNull(jsonElement["correlationEnabled"])
+        assertEquals("true", jsonElement["correlationEnabled"]?.jsonPrimitive?.content)
+        assertEquals("42", jsonElement["correlationValue"]?.jsonPrimitive?.content)
+        assertEquals("false", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun attributeInfo_withCorrelationEnabledTrue_noCorrelationValue_shouldParseCorrectly() {
+        // Given - correlationEnabled = true, no correlationValue
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{\"correlationEnabled\":true,\"denyReasonEnabled\":false}"),
+            uri = "mmfa:request:extras",
+            transactionId = "b400d358-2410-48c3-984b-02afa2110844"
+        )
+
+        // When
+        val jsonString = attribute.values.first()
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(jsonString).jsonObject
+
+        // Then
+        assertNotNull(jsonElement["correlationEnabled"])
+        assertEquals(null, jsonElement["correlationValue"])
+        assertNotNull(jsonElement["denyReasonEnabled"])
+    }
+
+    @Test
+    fun attributeInfo_withoutCorrelationEnabled_shouldParseCorrectly() {
+        // Given - without correlationEnabled, no correlationValue
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{\"denyReasonEnabled\":true}"),
+            uri = "mmfa:request:extras",
+            transactionId = "test-transaction-id"
+        )
+
+        // When
+        val jsonString = attribute.values.first()
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(jsonString).jsonObject
+
+        // Then
+        assertEquals(null, jsonElement["correlationEnabled"])
+        assertEquals(null, jsonElement["correlationValue"])
+        assertNotNull(jsonElement["denyReasonEnabled"])
+    }
+
+    @Test
+    fun attributeInfo_withDenyReasonEnabledAsBoolean_shouldParseCorrectly() {
+        // Given - denyReasonEnabled as boolean
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{\"denyReasonEnabled\":true}"),
+            uri = "mmfa:request:extras",
+            transactionId = "test-id"
+        )
+
+        // When
+        val jsonString = attribute.values.first()
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(jsonString).jsonObject
+
+        // Then
+        assertNotNull(jsonElement["denyReasonEnabled"])
+        assertEquals("true", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun attributeInfo_withDenyReasonEnabledAsString_shouldParseCorrectly() {
+        // Given - denyReasonEnabled as string "true"
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{\"denyReasonEnabled\":\"true\"}"),
+            uri = "mmfa:request:extras",
+            transactionId = "test-id"
+        )
+
+        // When
+        val jsonString = attribute.values.first()
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(jsonString).jsonObject
+
+        // Then
+        assertNotNull(jsonElement["denyReasonEnabled"])
+        assertEquals("true", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun attributeInfo_withAllFieldsAsStrings_shouldParseCorrectly() {
+        // Given - All fields as strings
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{\"correlationValue\":\"99\",\"correlationEnabled\":\"true\",\"denyReasonEnabled\":\"true\"}"),
+            uri = "mmfa:request:extras",
+            transactionId = "test-id"
+        )
+
+        // When
+        val jsonString = attribute.values.first()
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(jsonString).jsonObject
+
+        // Then
+        assertEquals("true", jsonElement["correlationEnabled"]?.jsonPrimitive?.content)
+        assertEquals("99", jsonElement["correlationValue"]?.jsonPrimitive?.content)
+        assertEquals("true", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
     }
 }
 

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/model/onprem/VerificationInfoTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/model/onprem/VerificationInfoTest.kt
@@ -13,7 +13,9 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 @RunWith(AndroidJUnit4::class)
 class VerificationInfoTest {
 
@@ -459,5 +461,109 @@ class VerificationInfoTest {
         assertEquals("second", info.keyHandles[1])
         assertEquals("third", info.keyHandles[2])
         assertEquals("fourth", info.keyHandles[3])
+    }
+
+    // Tests for expiryTime field
+    @OptIn(kotlin.time.ExperimentalTime::class)
+    @Test
+    fun constructor_withExpiryTime_shouldSetExpiryTime() {
+        // Given
+        val expiryTime = kotlin.time.Instant.fromEpochMilliseconds(1640005000000)
+        
+        // When
+        val info = VerificationInfo(
+            mechanism = testMechanism,
+            location = testLocation,
+            type = testType,
+            serverChallenge = testServerChallenge,
+            keyHandles = testKeyHandles,
+            expiryTime = expiryTime
+        )
+
+        // Then
+        assertEquals(expiryTime, info.expiryTime)
+    }
+
+    @Test
+    fun constructor_withoutExpiryTime_shouldUseNull() {
+        // When
+        val info = VerificationInfo(
+            mechanism = testMechanism,
+            location = testLocation,
+            type = testType,
+            serverChallenge = testServerChallenge,
+            keyHandles = testKeyHandles
+        )
+
+        // Then
+        assertEquals(null, info.expiryTime)
+    }
+
+    @OptIn(kotlin.time.ExperimentalTime::class)
+    @Test
+    fun serialization_withExpiryTime_shouldSerializeAndDeserialize() {
+        // Given
+        val expiryTime = kotlin.time.Instant.fromEpochMilliseconds(1640005000000)
+        val info = VerificationInfo(
+            mechanism = testMechanism,
+            location = testLocation,
+            type = testType,
+            serverChallenge = testServerChallenge,
+            keyHandles = testKeyHandles,
+            expiryTime = expiryTime
+        )
+        val json = Json { prettyPrint = true }
+
+        // When
+        val serialized = json.encodeToString(info)
+        val deserialized = json.decodeFromString<VerificationInfo>(serialized)
+
+        // Then
+        assertEquals(info.expiryTime, deserialized.expiryTime)
+    }
+
+    @OptIn(kotlin.time.ExperimentalTime::class)
+    @Test
+    fun copy_withModifiedExpiryTime_shouldUpdateOnlyExpiryTime() {
+        // Given
+        val originalExpiryTime = kotlin.time.Instant.fromEpochMilliseconds(1640000000000)
+        val newExpiryTime = kotlin.time.Instant.fromEpochMilliseconds(1640005000000)
+        val original = VerificationInfo(
+            mechanism = testMechanism,
+            location = testLocation,
+            type = testType,
+            serverChallenge = testServerChallenge,
+            keyHandles = testKeyHandles,
+            expiryTime = originalExpiryTime
+        )
+
+        // When
+        val modified = original.copy(expiryTime = newExpiryTime)
+
+        // Then
+        assertEquals(newExpiryTime, modified.expiryTime)
+        assertEquals(original.mechanism, modified.mechanism)
+        assertEquals(original.location, modified.location)
+    }
+
+    @Test
+    fun deserialization_withoutExpiryTime_shouldUseNull() {
+        // Given
+        val jsonString = """
+            {
+                "mechanism": "$testMechanism",
+                "location": "$testLocation",
+                "type": "$testType",
+                "serverChallenge": "$testServerChallenge",
+                "keyHandles": ["keyHandle1"]
+            }
+        """.trimIndent()
+        val json = Json { ignoreUnknownKeys = true }
+
+        // When
+        val info = json.decodeFromString<VerificationInfo>(jsonString)
+
+        // Then
+        assertEquals(null, info.expiryTime)
     }
 }

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFAServiceController.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFAServiceController.kt
@@ -4,10 +4,12 @@
 
 package com.ibm.security.verifysdk.mfa
 
+import com.ibm.security.verifysdk.core.helper.NetworkHelper
 import com.ibm.security.verifysdk.mfa.api.CloudAuthenticatorService
 import com.ibm.security.verifysdk.mfa.api.OnPremiseAuthenticatorService
 import com.ibm.security.verifysdk.mfa.model.cloud.CloudAuthenticator
 import com.ibm.security.verifysdk.mfa.model.onprem.OnPremiseAuthenticator
+import io.ktor.client.HttpClient
 
 /**
  * An instance you use to instantiate an [MFAServiceDescriptor] to perform transaction,
@@ -124,7 +126,10 @@ class MFAServiceController(private val authenticator: MFAAuthenticatorDescriptor
      * @see CloudAuthenticatorService
      * @see OnPremiseAuthenticatorService
      */
-    fun initiate(): MFAServiceDescriptor {
+    fun initiate(
+        httpClient: HttpClient = NetworkHelper.getInstance,
+        persistenceCallback: TokenPersistenceCallback? = null
+    ): MFAServiceDescriptor {
 
         when (authenticator) {
             is OnPremiseAuthenticator -> return OnPremiseAuthenticatorService(
@@ -133,14 +138,18 @@ class MFAServiceController(private val authenticator: MFAAuthenticatorDescriptor
                 _transactionUri = authenticator.transactionUri,
                 _clientId = authenticator.clientId,
                 _authenticatorId = authenticator.id,
-                _ignoreSslCertificate = authenticator.ignoreSSLCertificate
+                httpClient = httpClient,
+                _ignoreSslCertificate = authenticator.ignoreSSLCertificate,
+                persistenceCallback = persistenceCallback
             )
 
             is CloudAuthenticator -> return CloudAuthenticatorService(
                 _accessToken = authenticator.token.accessToken,
                 _refreshUri = authenticator.refreshUri,
                 _transactionUri = authenticator.transactionUri,
-                _authenticatorId = authenticator.id
+                _authenticatorId = authenticator.id,
+                httpClient = httpClient,
+                persistenceCallback = persistenceCallback
             )
 
             else -> throw MFARegistrationException.InvalidFormat()

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFAServiceDescriptor.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFAServiceDescriptor.kt
@@ -5,7 +5,9 @@
 package com.ibm.security.verifysdk.mfa
 
 import android.util.Base64
+import androidx.biometric.BiometricPrompt
 import com.ibm.security.verifysdk.authentication.model.TokenInfo
+import com.ibm.security.verifysdk.core.helper.KeystoreHelper
 import com.ibm.security.verifysdk.core.helper.NetworkHelper
 import io.ktor.client.HttpClient
 import io.ktor.client.request.accept
@@ -64,7 +66,6 @@ interface MFAServiceDescriptor {
     val accessToken: String
     val refreshUri: URL
     val transactionUri: URL
-    val currentPendingTransaction: PendingTransactionInfo?
     val authenticatorId: String
 
     /**
@@ -79,7 +80,6 @@ interface MFAServiceDescriptor {
      *                  or null if push notifications are not used.
      * @param additionalData (Optional) A collection of options associated with the service.
      *                      This is primarily used for on-premise registrations.
-     * @param httpClient The HTTP client to use for the request. Defaults to [NetworkHelper.getInstance].
      *
      * @return A [Result] containing either:
      *         - Success: A new [TokenInfo] with updated access and refresh tokens
@@ -91,8 +91,7 @@ interface MFAServiceDescriptor {
         refreshToken: String,
         accountName: String?,
         pushToken: String?,
-        additionalData: Map<String, Any>?,
-        httpClient: HttpClient = NetworkHelper.getInstance
+        additionalData: Map<String, Any>?
     ): Result<TokenInfo>
 
     /**
@@ -102,7 +101,6 @@ interface MFAServiceDescriptor {
      * is returned while in a PENDING state. Otherwise, the next available transaction is returned.
      *
      * @param transactionID The transaction verification identifier, or null to get the next transaction.
-     * @param httpClient The HTTP client to use for the request. Defaults to [NetworkHelper.getInstance].
      *
      * @return A [Result] containing either:
      *         - Success: A [NextTransactionInfo] with the transaction details and count of pending transactions
@@ -112,8 +110,7 @@ interface MFAServiceDescriptor {
      * @see PendingTransactionInfo
      */
     suspend fun nextTransaction(
-        transactionID: String? = null,
-        httpClient: HttpClient = NetworkHelper.getInstance
+        transactionID: String? = null
     ): Result<NextTransactionInfo>
 
     /**
@@ -122,21 +119,22 @@ interface MFAServiceDescriptor {
      * This method submits the user's action (approve, deny, etc.) along with the signed data
      * to complete the transaction verification process.
      *
+     * @param transaction The pending transaction to complete. This must be obtained from a prior call to [nextTransaction].
      * @param userAction The enumerated type of user actions that can be performed to complete a transaction.
      * @param signedData The base64 encoded value using the private key associated with the factor enrollment.
      *                  This should be an empty string for actions other than [UserAction.VERIFY].
-     * @param httpClient The HTTP client to use for the request. Defaults to [NetworkHelper.getInstance].
      *
      * @return A [Result] containing either:
      *         - Success: Unit indicating the transaction was completed successfully
      *         - Failure: An exception indicating why the operation failed
      *
      * @see UserAction
+     * @see PendingTransactionInfo
      */
     suspend fun completeTransaction(
+        transaction: PendingTransactionInfo,
         userAction: UserAction,
-        signedData: String,
-        httpClient: HttpClient = NetworkHelper.getInstance
+        signedData: String
     ): Result<Unit>
 }
 
@@ -144,15 +142,15 @@ interface MFAServiceDescriptor {
  * A type alias representing the next transaction information.
  *
  * This is a pair containing:
- * - First: The [PendingTransactionInfo] for the current transaction, or null if no transaction is pending
+ * - First: A list of [PendingTransactionInfo] for all pending transactions (empty list if none)
  * - Second: The count of pending transactions associated with the authenticator
  *
  * ## Usage Example
  * ```kotlin
- * service.nextTransaction().onSuccess { (transaction, count) ->
- *     if (transaction != null) {
- *         println("Current transaction: ${transaction.message}")
- *         println("Remaining transactions: ${count - 1}")
+ * service.nextTransaction().onSuccess { (transactions, count) ->
+ *     if (transactions.isNotEmpty()) {
+ *         println("First transaction: ${transactions.first().message}")
+ *         println("Total transactions: $count")
  *     } else {
  *         println("No pending transactions")
  *     }
@@ -161,7 +159,7 @@ interface MFAServiceDescriptor {
  *
  * @see PendingTransactionInfo
  */
-typealias NextTransactionInfo = Pair<PendingTransactionInfo?, Int>
+typealias NextTransactionInfo = Pair<List<PendingTransactionInfo>, Int>
 
 /**
  * Performs a passwordless authentication operation.
@@ -190,7 +188,6 @@ typealias NextTransactionInfo = Pair<PendingTransactionInfo?, Int>
  * @param loginUri The endpoint that performs the passwordless login. The URL is provided as
  *                `qrlogin_endpoint` in the response data returned from a QR scan.
  * @param code The authorization code provided in the QR scan.
- * @param httpClient The HTTP client to use for the request. Defaults to [NetworkHelper.getInstance].
  *
  * @return A [Result] containing either:
  *         - Success: Unit indicating the login was successful
@@ -200,9 +197,14 @@ typealias NextTransactionInfo = Pair<PendingTransactionInfo?, Int>
  */
 suspend fun MFAServiceDescriptor.login(
     loginUri: URL,
-    code: String,
-    httpClient: HttpClient = NetworkHelper.getInstance
+    code: String
 ): Result<Unit> {
+    // Get httpClient from service implementation
+    val httpClient = when (this) {
+        is com.ibm.security.verifysdk.mfa.api.CloudAuthenticatorService -> this.httpClient
+        is com.ibm.security.verifysdk.mfa.api.OnPremiseAuthenticatorService -> this.httpClient
+        else -> NetworkHelper.getInstance
+    }
     val body = buildJsonObject {
         put("lsi", code)
     }
@@ -272,7 +274,6 @@ suspend fun MFAServiceDescriptor.login(
  *                  Defaults to [UserAction.VERIFY].
  * @param factorType The enrolled factor associated with the transaction. This is used to retrieve
  *                  the private key for signing the transaction data.
- * @param httpClient The HTTP client to use for the request. Defaults to [NetworkHelper.getInstance].
  *
  * @return A [Result] containing either:
  *         - Success: Unit indicating the transaction was completed successfully
@@ -287,29 +288,136 @@ suspend fun MFAServiceDescriptor.login(
  */
 @OptIn(InternalSerializationApi::class)
 suspend fun MFAServiceDescriptor.completeTransaction(
+    transaction: PendingTransactionInfo,
     userAction: UserAction = UserAction.VERIFY,
-    factorType: FactorType,
-    httpClient: HttpClient = NetworkHelper.getInstance
+    factorType: FactorType
 ): Result<Unit> {
     var signedData = ""
-    val pendingTransaction =
-        currentPendingTransaction ?: throw MFAServiceException.InvalidPendingTransaction()
 
     if (userAction == UserAction.VERIFY) {
         val (keyName, algorithm) = factorKeyNameAndAlgorithm(factorType)
         signedData = sign(
             keyName = keyName,
             algorithm = HashAlgorithmType.forSigning(algorithm.name),
-            dataToSign = pendingTransaction.dataToSign,
+            dataToSign = transaction.dataToSign,
             base64EncodingOptions = Base64.NO_WRAP
         )
     }
 
     return completeTransaction(
+        transaction = transaction,
         userAction = userAction,
-        signedData = signedData,
-        httpClient = httpClient
+        signedData = signedData
     )
+}
+
+/**
+ * Complete a second factor authentication challenge using a [BiometricPrompt.CryptoObject]
+ * obtained from [BiometricPrompt.AuthenticationResult.getCryptoObject] in
+ * [BiometricPrompt.AuthenticationCallback.onAuthenticationSucceeded].
+ *
+ * Use this overload when the enrolled key was created with
+ * `authenticationRequired = true` (i.e. the key is locked until the user authenticates
+ * with biometrics).  The [cryptoObject] carries the hardware-unlocked [java.security.Signature]
+ * that is used to sign the transaction data without ever exposing the raw private key.
+ *
+ * ## Typical usage
+ * ```kotlin
+ * // 1. Before showing the prompt, obtain a CryptoObject for the factor's key.
+ * val cryptoObject = service.getCryptoObjectForTransaction()
+ *
+ * // 2. Show the BiometricPrompt with the CryptoObject.
+ * biometricPrompt.authenticate(promptInfo, cryptoObject)
+ *
+ * // 3. In onAuthenticationSucceeded, complete the transaction.
+ * override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+ *     lifecycleScope.launch {
+ *         service.completeTransaction(
+ *             userAction = UserAction.VERIFY,
+ *             cryptoObject = result.cryptoObject!!
+ *         )
+ *     }
+ * }
+ * ```
+ *
+ * @receiver The [MFAServiceDescriptor] instance to perform the transaction completion.
+ * @param userAction The enumerated type of user actions. Defaults to [UserAction.VERIFY].
+ * @param cryptoObject The authenticated [BiometricPrompt.CryptoObject] whose embedded
+ *                     [java.security.Signature] has been unlocked by the biometric hardware.
+ *
+ * @return A [Result] containing either:
+ *         - Success: Unit indicating the transaction was completed successfully
+ *         - Failure: An exception indicating why the operation failed
+ *
+ * @throws MFAServiceException.InvalidPendingTransaction if no pending transaction exists.
+ *
+ * @see MFAServiceDescriptor.completeTransaction
+ * @see getCryptoObjectForTransaction
+ * @see UserAction
+ */
+suspend fun MFAServiceDescriptor.completeTransaction(
+    transaction: PendingTransactionInfo,
+    userAction: UserAction = UserAction.VERIFY,
+    cryptoObject: BiometricPrompt.CryptoObject
+): Result<Unit> {
+    var signedData = ""
+
+    if (userAction == UserAction.VERIFY) {
+        signedData = sign(
+            cryptoObject = cryptoObject,
+            dataToSign = transaction.dataToSign,
+            base64EncodingOptions = Base64.NO_WRAP
+        )
+    }
+
+    return completeTransaction(
+        transaction = transaction,
+        userAction = userAction,
+        signedData = signedData
+    )
+}
+
+/**
+ * Creates a [BiometricPrompt.CryptoObject] for the factor associated with the current pending
+ * transaction.
+ *
+ * Call this **before** invoking [BiometricPrompt.authenticate] so that the biometric hardware
+ * can unlock the key and return an authenticated [java.security.Signature] inside
+ * [BiometricPrompt.AuthenticationResult].  This is only required when the key was enrolled
+ * with `authenticationRequired = true`.
+ *
+ * If the current pending transaction has no matching factor, or the key does not exist in the
+ * Android Keystore, `null` is returned and you should fall back to the non-biometric
+ * [completeTransaction] overload.
+ *
+ * ## Usage
+ * ```kotlin
+ * val cryptoObject = service.getCryptoObjectForTransaction(factorType)
+ * if (cryptoObject != null) {
+ *     biometricPrompt.authenticate(promptInfo, cryptoObject)
+ * } else {
+ *     // Key does not require biometric unlock – complete directly.
+ *     service.completeTransaction(UserAction.VERIFY, factorType)
+ * }
+ * ```
+ *
+ * @receiver The [MFAServiceDescriptor] instance.
+ * @param factorType The enrolled factor whose private key should be wrapped.
+ *
+ * @return A [BiometricPrompt.CryptoObject] ready to be passed to
+ *         [BiometricPrompt.authenticate], or `null` if the key cannot be found or does not
+ *         require authentication.
+ *
+ * @see completeTransaction
+ * @see KeystoreHelper.getCryptoObject
+ */
+@OptIn(InternalSerializationApi::class)
+fun MFAServiceDescriptor.getCryptoObjectForTransaction(
+    factorType: FactorType
+): BiometricPrompt.CryptoObject? {
+    val (keyName, algorithm) = factorKeyNameAndAlgorithm(factorType)
+    val signingAlgorithm = HashAlgorithmType.forSigning(algorithm.name)
+    return KeystoreHelper.getCryptoObject(keyName, signingAlgorithm)
 }
 
 /**

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/PendingTransactionInfo.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/PendingTransactionInfo.kt
@@ -24,7 +24,8 @@ data class PendingTransactionInfo (
     val factorID: UUID,
     val factorType: String,
     val dataToSign: String,
-    val timeStamp: Instant,
+    val creationTime: Instant,
+    val expiryTime: Instant? = null,
     val additionalData: Map<TransactionAttribute, String>
 ) {
     val shortId: String

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/TransactionAttribute.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/TransactionAttribute.kt
@@ -6,12 +6,43 @@ package com.ibm.security.verifysdk.mfa
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Represents additional attributes that can be associated with a transaction.
+ *
+ * These attributes provide contextual information about the transaction request,
+ * including network details, correlation data, and user interaction requirements.
+ */
 @Serializable
 enum class TransactionAttribute(val rawValue: String) {
+    /** The IP address from which the transaction originated */
     IPAddress("ipAddress"),
+    
+    /** The geographic location of the transaction origin */
     Location("location"),
+    
+    /** URL to an image associated with the transaction */
     Image("image"),
+    
+    /** The user agent string of the client making the transaction request */
     UserAgent("userAgent"),
+    
+    /** The type of transaction being performed */
     Type("type"),
-    Custom("custom")
+    
+    /** Custom attribute for application-specific data */
+    Custom("custom"),
+    
+    /**
+     * The correlation value for the transaction, typically a 2-digit number (00-99).
+     * This value is set when correlationEnabled is true in the transaction extras.
+     * If correlationValue is provided, it is used directly; otherwise, it is calculated
+     * from the transaction ID. Used primarily with OnPremise authenticators.
+     */
+    Correlation("correlation"),
+    
+    /**
+     * Indicates whether the user can provide a reason when denying the transaction.
+     * Used primarily with OnPremise authenticators.
+     */
+    DenyReason("denyReason")
 }

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudAuthenticatorService.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudAuthenticatorService.kt
@@ -4,9 +4,13 @@
 
 package com.ibm.security.verifysdk.mfa.api
 
+import android.util.Log
 import com.ibm.security.verifysdk.authentication.model.TokenInfo
 import com.ibm.security.verifysdk.core.AuthorizationException
 import com.ibm.security.verifysdk.core.ErrorMessage
+import com.ibm.security.verifysdk.core.extension.logDebug
+import com.ibm.security.verifysdk.core.extension.logError
+import com.ibm.security.verifysdk.core.extension.logInfo
 import com.ibm.security.verifysdk.core.helper.NetworkHelper
 import com.ibm.security.verifysdk.core.serializer.DefaultJson
 import com.ibm.security.verifysdk.mfa.MFAAttributeInfo
@@ -14,6 +18,7 @@ import com.ibm.security.verifysdk.mfa.MFAServiceDescriptor
 import com.ibm.security.verifysdk.mfa.MFAServiceException
 import com.ibm.security.verifysdk.mfa.NextTransactionInfo
 import com.ibm.security.verifysdk.mfa.PendingTransactionInfo
+import com.ibm.security.verifysdk.mfa.TokenPersistenceCallback
 import com.ibm.security.verifysdk.mfa.TransactionAttribute
 import com.ibm.security.verifysdk.mfa.UserAction
 import com.ibm.security.verifysdk.mfa.model.cloud.TransactionResult
@@ -32,6 +37,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.content.TextContent
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.addJsonObject
@@ -39,8 +45,6 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
-import org.json.JSONArray
-import org.json.JSONObject
 import java.net.URL
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -48,16 +52,128 @@ import java.util.Locale
 import java.util.UUID
 import kotlin.time.ExperimentalTime
 
+/**
+ * Immutable cloud-based MFA authenticator service.
+ *
+ * ## Design Philosophy
+ * This service is an **immutable value object** that represents a snapshot of authenticator
+ * state at a specific point in time. It is NOT a traditional stateful service that maintains
+ * and updates its state over time.
+ *
+ * ## Lifecycle Pattern
+ * ```kotlin
+ * // 1. Create service with current token and HTTP client
+ * val service = CloudAuthenticatorService(
+ *     _accessToken = authenticator.token.accessToken,
+ *     _refreshUri = authenticator.refreshUri,
+ *     _transactionUri = authenticator.transactionUri,
+ *     _authenticatorId = authenticator.id,
+ *     httpClient = NetworkHelper.getInstance,
+ *     persistenceCallback = repository
+ * )
+ *
+ * // 2. Use service for operations
+ * service.nextTransaction()
+ * service.completeTransaction(...)
+ *
+ * // 3. If token is refreshed, create NEW service
+ * service.refreshToken(...).onSuccess { newToken ->
+ *     // This service is now obsolete!
+ *     // Create new service with new token:
+ *     val newService = CloudAuthenticatorService(
+ *         _accessToken = newToken.accessToken,  // New token
+ *         _refreshUri = authenticator.refreshUri,
+ *         _transactionUri = authenticator.transactionUri,
+ *         _authenticatorId = authenticator.id,
+ *         httpClient = NetworkHelper.getInstance,
+ *         persistenceCallback = repository
+ *     )
+ *     // Use newService for subsequent operations
+ * }
+ * ```
+ *
+ * ## Why Immutable?
+ *
+ * ### Thread Safety
+ * Immutability guarantees thread safety without synchronization:
+ * - Multiple threads can safely call methods concurrently
+ * - No race conditions or data corruption
+ * - No need for locks or mutexes in the service
+ *
+ * ### Clear Semantics
+ * Immutability makes the lifecycle explicit:
+ * - Service represents a point-in-time snapshot
+ * - When token changes, create new service
+ * - No hidden state mutations
+ * - Clear ownership and lifecycle
+ *
+ * ### Lightweight
+ * Creating new instances is fast (~1ms):
+ * - No expensive initialization
+ * - No resource allocation
+ * - Just property assignment
+ *
+ * ## Repository Pattern
+ * The repository layer manages service lifecycle:
+ * ```kotlin
+ * suspend fun <T> executeWithTokenManagement(
+ *     authenticator: MFAAuthenticatorDescriptor,
+ *     operation: suspend (MFAServiceDescriptor) -> Result<T>
+ * ): Result<T> {
+ *     // 1. Check if token needs refresh
+ *     if (authenticator.token.shouldRefresh()) {
+ *         refreshAndSaveToken(authenticator)
+ *     }
+ *
+ *     // 2. Create service with current token
+ *     val service = createService(authenticator)
+ *
+ *     // 3. Execute operation
+ *     val result = operation(service)
+ *
+ *     // 4. Handle 401 errors
+ *     if (result.isFailure && is401Error(result)) {
+ *         refreshAndSaveToken(authenticator)
+ *         val newService = createService(authenticator)  // New instance!
+ *         return operation(newService)
+ *     }
+ *
+ *     return result
+ * }
+ * ```
+ *
+ * ## Terminology
+ * This service is:
+ * - ✅ **Immutable** - state cannot change
+ * - ✅ **Thread-safe** - safe for concurrent use
+ * - ✅ **Value object** - represents a snapshot
+ * - ✅ **Short-lived** - created per operation or set of operations
+ * - ❌ **NOT stateless** - holds immutable state
+ * - ❌ **NOT long-lived** - recreated when token changes
+ *
+ * @property _accessToken The OAuth access token (immutable snapshot)
+ * @property _refreshUri The endpoint URL for token refresh operations
+ * @property _transactionUri The endpoint URL for transaction operations
+ * @property _authenticatorId The unique identifier for this authenticator
+ * @property httpClient The HTTP client for making network requests
+ * @property persistenceCallback Optional callback for automatic token persistence
+ *
+ * @see MFAServiceDescriptor
+ * @see TokenPersistenceCallback
+ */
 @OptIn(ExperimentalSerializationApi::class, ExperimentalTime::class)
 class CloudAuthenticatorService(
-    private var _accessToken: String,
-    private var _refreshUri: URL,
-    private var _transactionUri: URL,
-    private var _authenticatorId: String
+    private val _accessToken: String,
+    private val _refreshUri: URL,
+    private val _transactionUri: URL,
+    private val _authenticatorId: String,
+    internal val httpClient: HttpClient,
+    private val persistenceCallback: TokenPersistenceCallback? = null
 ) : MFAServiceDescriptor {
 
-    private var _currentPendingTransaction: PendingTransactionInfo? = null
-    private var transactionResult: TransactionResult? = null
+    companion object {
+        private const val TAG = "CloudAuthService"
+    }
 
     override val accessToken: String
         get() = _accessToken
@@ -67,9 +183,6 @@ class CloudAuthenticatorService(
 
     override val transactionUri: URL
         get() = _transactionUri
-
-    override val currentPendingTransaction: PendingTransactionInfo?
-        get() = _currentPendingTransaction
 
     override val authenticatorId: String
         get() = _authenticatorId
@@ -81,36 +194,160 @@ class CloudAuthenticatorService(
         fun build(transactionId: String? = null): String =
             when (this) {
                 NEXT_PENDING ->
-                    """?filter=id,creationTime,transactionData,authenticationMethods,correlationEnabled,correlationValue,&search=state="PENDING"&sort=-creationTime"""
+                    """?filter=id,creationTime,transactionData,authenticationMethods,correlationEnabled,correlationValue,expiryTime,&search=state="PENDING"&sort=-creationTime"""
 
                 PENDING_BY_IDENTIFIER ->
-                    """?filter=id,creationTime,transactionData,authenticationMethods,correlationEnabled,correlationValue,&search=state="PENDING"&id="$transactionId""""
+                    """?filter=id,creationTime,transactionData,authenticationMethods,correlationEnabled,correlationValue,expiryTime,&search=state="PENDING"&id="$transactionId""""
             }
     }
 
     /**
-     * Refreshes the token by making a network request to the refresh URI.
+     * Refreshes the OAuth token with **CRITICAL** persistence guarantees.
      *
-     * @param refreshToken The refresh token to be used.
+     * ## ⚠️ CRITICAL: Token Persistence
+     *
+     * This method implements **BLOCKING, ATOMIC** token persistence to prevent the
+     * "hosed authenticator" scenario where the app crashes after token refresh but
+     * before persistence, leaving the authenticator permanently broken.
+     *
+     * ### How It Works
+     * 1. Makes network request to refresh endpoint
+     * 2. Receives new access token from server
+     * 3. **BLOCKS** until [persistenceCallback] completes
+     * 4. Only returns success if persistence succeeds
+     * 5. If persistence fails, entire refresh fails
+     *
+     * ### Why This Matters
+     * Once the server sees a new token in an API call, it marks the old token as invalid.
+     * If the new token isn't persisted before that happens, the authenticator becomes
+     * permanently unusable because:
+     * - Server has activated new token (old token now invalid)
+     * - New token was never saved to database
+     * - On app restart: old token loaded → all API calls fail with 401
+     * - **Authenticator is permanently broken** (requires re-registration)
+     *
+     * ### Atomicity Guarantee
+     * ```
+     * Token Refresh = Network Call + Database Save
+     * ```
+     * Both must succeed, or the entire operation fails. This prevents partial state.
+     *
+     * ### Service Lifecycle
+     * **IMPORTANT:** This service instance becomes obsolete after token refresh.
+     * You must create a new service instance with the new token:
+     * ```kotlin
+     * service.refreshToken(...).onSuccess { newToken ->
+     *     // This service is now obsolete!
+     *     val newService = CloudAuthenticatorService(
+     *         _accessToken = newToken.accessToken,  // New token
+     *         _refreshUri = authenticator.refreshUri,
+     *         _transactionUri = authenticator.transactionUri,
+     *         _authenticatorId = authenticator.id,
+     *         persistenceCallback = repository
+     *     )
+     *     // Use newService for subsequent operations
+     * }
+     * ```
+     *
+     * ### Synchronization
+     * **Note:** Concurrent refresh prevention should be handled at the repository layer
+     * using a Mutex to ensure only one refresh per authenticator at a time.
+     *
+     * @param refreshToken The refresh token to be used for obtaining a new access token.
      * @param accountName Optional account name to be included in the request attributes.
-     * @param pushToken Optional push token to be included in the request attributes.
+     * @param pushToken Optional push token (e.g., FCM token) to be included in the request.
      * @param additionalData Additional data to be included in the request (currently unused).
-     * @return A [Result] containing the new [TokenInfo] if the request is successful, or an error if it fails.
+     *
+     * @return A [Result] containing:
+     *         - **Success:** New [TokenInfo] with updated access and refresh tokens.
+     *                       Token has been persisted to database via callback.
+     *         - **Failure:** Exception indicating why the refresh failed. This includes
+     *                       persistence failures - if token can't be saved, refresh fails.
+     *
+     * @throws Exception if network request fails
+     * @throws Exception if token persistence fails (via callback)
+     *
+     * @sample
+     * ```kotlin
+     * // Create service with current token and persistence callback
+     * val service = CloudAuthenticatorService(
+     *     _accessToken = authenticator.token.accessToken,
+     *     _refreshUri = authenticator.refreshUri,
+     *     _transactionUri = authenticator.transactionUri,
+     *     _authenticatorId = authenticator.id,
+     *     httpClient = NetworkHelper.getInstance,
+     *     persistenceCallback = repository // Implements TokenPersistenceCallback
+     * )
+     *
+     * // Refresh the token
+     * service.refreshToken(
+     *     refreshToken = authenticator.token.refreshToken,
+     *     accountName = "user@example.com",
+     *     pushToken = "fcm-token-abc123",
+     *     additionalData = null
+     * ).onSuccess { newToken ->
+     *     println("Token refreshed successfully")
+     *     println("New access token: ${newToken.accessToken}")
+     *     println("Expires in: ${newToken.expiresIn} seconds")
+     *
+     *     // IMPORTANT: Create new service with new token
+     *     val newService = CloudAuthenticatorService(
+     *         _accessToken = newToken.accessToken,  // Use new token
+     *         _refreshUri = authenticator.refreshUri,
+     *         _transactionUri = authenticator.transactionUri,
+     *         _authenticatorId = authenticator.id,
+     *         httpClient = NetworkHelper.getInstance,
+     *         persistenceCallback = repository
+     *     )
+     *
+     *     // Use newService for subsequent operations
+     *     newService.nextTransaction()
+     * }.onFailure { error ->
+     *     println("Token refresh failed: ${error.message}")
+     *     // Handle error (e.g., re-authenticate user)
+     * }
+     * ```
+     *
+     * @see TokenInfo
+     * @see TokenPersistenceCallback
      */
     override suspend fun refreshToken(
         refreshToken: String,
         accountName: String?,
         pushToken: String?,
-        additionalData: Map<String, Any>?,
-        httpClient: HttpClient
+        additionalData: Map<String, Any>?
     ): Result<TokenInfo> {
-
         return try {
-            val attributes = refreshTokenPrepareAttributes(accountName, pushToken)
-            val response = refreshTokenMakeNetworkRequest(refreshToken, attributes, httpClient)
+            logDebug(TAG) { "Starting token refresh for authenticator $_authenticatorId" }
+            
+            val attributes = prepareAttributes(accountName, pushToken)
+            val response = makeNetworkRequest(refreshToken, attributes)
 
-            refreshTokenHandleResponse(response)
+            handleResponse(response).also { result ->
+                result.onSuccess { newTokenInfo ->
+                    logInfo(TAG) { "Token refreshed successfully for authenticator $_authenticatorId" }
+                    
+                    // CRITICAL: Persist token BEFORE returning success
+                    // This ensures token is saved BEFORE any subsequent API call that would activate it on server
+                    persistenceCallback?.let { callback ->
+                        val persistResult = callback.onTokenRefreshed(authenticatorId, newTokenInfo)
+                        persistResult.onFailure { error ->
+                            logError(TAG) { "CRITICAL: Token persistence failed for authenticator $_authenticatorId: ${error.message}" }
+                            // Return failure if persistence fails - token refresh is not complete without persistence
+                            return Result.failure(Exception("Token refresh succeeded but persistence failed: ${error.message}", error))
+                        }
+                        logDebug(TAG) { "Token persisted successfully for authenticator $_authenticatorId" }
+                    }
+                }.onFailure { error ->
+                    logError(TAG) { "Token refresh failed for authenticator $_authenticatorId: ${error.message}" }
+                }
+            }
+        } catch (e: CancellationException) {
+            // Coroutine was cancelled - this is normal, don't log as error
+            // Re-throw to allow proper cancellation propagation
+            throw e
         } catch (e: Throwable) {
+            logError(TAG, e) { "Exception during token refresh for authenticator $_authenticatorId" }
             Result.failure(e)
         }
     }
@@ -122,7 +359,7 @@ class CloudAuthenticatorService(
      * @param pushToken Optional push token to be included in the attributes.
      * @return A mutable map of attributes with the provided account name and push token.
      */
-    private fun refreshTokenPrepareAttributes(
+    private fun prepareAttributes(
         accountName: String?,
         pushToken: String?
     ): MutableMap<String, Any> {
@@ -139,12 +376,12 @@ class CloudAuthenticatorService(
      *
      * @param refreshToken The refresh token to be included in the request.
      * @param attributes The attributes to be included in the request.
+     * @param httpClient The HTTP client to use for the request.
      * @return The HTTP response from the server.
      */
-    private suspend fun refreshTokenMakeNetworkRequest(
+    private suspend fun makeNetworkRequest(
         refreshToken: String,
-        attributes: Map<String, Any>,
-        httpClient: HttpClient = NetworkHelper.getInstance
+        attributes: Map<String, Any>
     ): HttpResponse {
         // Build JSON manually to avoid serialization issues with Map<String, Any>
         val jsonBody = buildJsonObject {
@@ -178,7 +415,7 @@ class CloudAuthenticatorService(
      * @param response The HTTP response from the server.
      * @return A [Result] containing the new [TokenInfo] if the response indicates success, or an error if it fails.
      */
-    private suspend fun refreshTokenHandleResponse(response: HttpResponse): Result<TokenInfo> {
+    private suspend fun handleResponse(response: HttpResponse): Result<TokenInfo> {
         return if (response.status.isSuccess()) {
             Result.success(DefaultJson.decodeFromString<TokenInfo>(response.bodyAsText()))
         } else {
@@ -201,12 +438,11 @@ class CloudAuthenticatorService(
      * @return A [Result] containing the [NextTransactionInfo] if successful, or an error if unsuccessful.
      */
     override suspend fun nextTransaction(
-        transactionID: String?,
-        httpClient: HttpClient
+        transactionID: String?
     ): Result<NextTransactionInfo> {
         return try {
             val uri = nextTransactionBuildTransactionUri(transactionID)
-            val response = nextTransactionMakeNetworkRequest(uri, httpClient)
+            val response = nextTransactionMakeNetworkRequest(uri)
 
             nextTransactionHandleResponse(response)
         } catch (e: Throwable) {
@@ -215,17 +451,42 @@ class CloudAuthenticatorService(
     }
 
     /**
+     * Safely builds a URL by appending a path to a base URL.
+     *
+     * This helper ensures proper URL construction by:
+     * - Removing trailing slashes from base URL
+     * - Ensuring path starts with a slash
+     * - Preventing double-slash issues
+     *
+     * @param baseUrl The base URL
+     * @param path The path to append (with or without leading slash)
+     * @return A properly constructed URL
+     */
+    private fun buildUrl(baseUrl: URL, path: String): URL {
+        val baseStr = baseUrl.toString().trimEnd('/')
+        val pathStr = if (path.startsWith('/')) path else "/$path"
+        return URL("$baseStr$pathStr")
+    }
+
+    /**
      * Builds the URI for retrieving the next pending transaction.
+     *
+     * Uses safe URL construction to prevent malformed URLs from trailing slashes
+     * or missing path separators. Validates that transaction ID is not blank.
      *
      * @param transactionID The ID of the transaction to retrieve. If null, retrieves the next pending transaction.
      * @return The URI for retrieving the next pending transaction.
+     * @throws IllegalArgumentException if transactionID is blank (empty or whitespace only)
      */
     private fun nextTransactionBuildTransactionUri(transactionID: String?): URL {
         return if (transactionID != null) {
+            require(transactionID.isNotBlank()) {
+                "Transaction ID cannot be blank (empty or whitespace only)"
+            }
             val encodedId = URLEncoder.encode(transactionID, StandardCharsets.UTF_8.name())
-            URL("$transactionUri${TransactionFilter.PENDING_BY_IDENTIFIER.build(encodedId)}")
+            buildUrl(transactionUri, TransactionFilter.PENDING_BY_IDENTIFIER.build(encodedId))
         } else {
-            URL("$transactionUri${TransactionFilter.NEXT_PENDING.build()}")
+            buildUrl(transactionUri, TransactionFilter.NEXT_PENDING.build())
         }
     }
 
@@ -236,8 +497,7 @@ class CloudAuthenticatorService(
      * @return The HTTP response.
      */
     private suspend fun nextTransactionMakeNetworkRequest(
-        uri: URL,
-        httpClient: HttpClient = NetworkHelper.getInstance
+        uri: URL
     ): HttpResponse {
         return httpClient.get {
             url(uri.toString())
@@ -256,33 +516,33 @@ class CloudAuthenticatorService(
     private suspend fun nextTransactionHandleResponse(response: HttpResponse): Result<NextTransactionInfo> {
         return if (response.status.isSuccess()) {
             parsePendingTransaction(response)
-                .fold(
-                    onSuccess = {
-                        _currentPendingTransaction = it.first
-                        Result.success(it)
-                    },
-                    onFailure = {
-                        _currentPendingTransaction = null
-                        Result.failure(it)
-                    })
         } else {
             Result.failure(MFAServiceException.General(response.bodyAsText()))
         }
     }
 
     override suspend fun completeTransaction(
+        transaction: PendingTransactionInfo,
         userAction: UserAction,
-        signedData: String,
-        httpClient: HttpClient
+        signedData: String
     ): Result<Unit> {
 
         return try {
-            val pendingTransaction =
-                currentPendingTransaction ?: throw MFAServiceException.InvalidPendingTransaction()
+            Log.d(TAG, "Completing transaction ${transaction.id} with action $userAction for authenticator $_authenticatorId")
+            
+            // Validate transaction hasn't expired
+            transaction.expiryTime?.let { expiry ->
+                if (kotlin.time.Clock.System.now() > expiry) {
+                    Log.w(TAG, "Transaction ${transaction.id} has expired for authenticator $_authenticatorId")
+                    return Result.failure(
+                        MFAServiceException.General("Transaction ${transaction.id} has expired")
+                    )
+                }
+            }
 
             val jsonBody = buildJsonArray {
                 addJsonObject {
-                    put("id", pendingTransaction.factorID.toString().lowercase(Locale.ROOT))
+                    put("id", transaction.factorID.toString().lowercase(Locale.ROOT))
                     put("userAction", userAction.value)
                     if (userAction == UserAction.VERIFY) {
                         put("signedData", signedData)
@@ -293,18 +553,21 @@ class CloudAuthenticatorService(
             }
 
             val response = httpClient.post {
-                url(pendingTransaction.postbackUri.toString())
+                url(transaction.postbackUri.toString())
                 accept(ContentType.Application.Json)
                 bearerAuth(accessToken)
                 setBody(TextContent(jsonBody.toString(), ContentType.Application.Json))
             }
 
             if (response.status.isSuccess()) {
+                Log.i(TAG, "Transaction ${transaction.id} completed successfully with action $userAction for authenticator $_authenticatorId")
                 Result.success(Unit)
             } else {
+                Log.e(TAG, "Failed to complete transaction ${transaction.id} for authenticator $_authenticatorId: ${response.bodyAsText()}")
                 Result.failure(MFAServiceException.General(response.bodyAsText()))
             }
         } catch (e: Throwable) {
+            Log.e(TAG, "Exception completing transaction ${transaction.id} for authenticator $_authenticatorId", e)
             return Result.failure(e)
         }
     }
@@ -315,40 +578,51 @@ class CloudAuthenticatorService(
             val responseBody = response.bodyAsText()
             val result: TransactionResult = try {
                 DefaultJson.decodeFromString(responseBody)
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 return Result.failure(MFAServiceException.DecodingFailed())
             }
 
             if (result.count == 0) {
-                Result.success(NextTransactionInfo(null, 0))
+                Result.success(NextTransactionInfo(emptyList(), 0))
             } else {
-                createPendingTransaction(result)?.let {
-                    Result.success(NextTransactionInfo(it, result.count))
-                } ?: kotlin.run {
-                    Result.failure(MFAServiceException.UnableToCreateTransaction())
-                }
+                val transactions = createPendingTransactions(result)
+                Result.success(NextTransactionInfo(transactions, result.count))
             }
 
-        } catch (e: Throwable) {
+        } catch (_: Throwable) {
             Result.failure(MFAServiceException.UnableToCreateTransaction())
         }
     }
 
-    private fun createPendingTransaction(result: TransactionResult): PendingTransactionInfo? {
-        // 1. Get the first transaction.
-        val verificationInfo = result.verifications?.first() ?: return null
+    private fun createPendingTransactions(result: TransactionResult): List<PendingTransactionInfo> {
+        val verifications = result.verifications ?: return emptyList()
+        val now = kotlin.time.Clock.System.now()
+        
+        return verifications.mapNotNull { verificationInfo ->
+            // Filter out expired transactions
+            verificationInfo.expiryTime?.let { expiry ->
+                if (now > expiry) {
+                    Log.d(TAG, "Skipping expired transaction ${verificationInfo.id}")
+                    return@mapNotNull null
+                }
+            }
+            
+            createPendingTransaction(verificationInfo)
+        }
+    }
 
-        // 2. Get the postback to the transaction.
-        val postbackUri = URL(transactionUri, "verifications/${verificationInfo.id}")
+    private fun createPendingTransaction(verificationInfo: TransactionResult.VerificationInfo): PendingTransactionInfo? {
+        // 1. Get the postback to the transaction using safe URL construction.
+        val postbackUri = buildUrl(transactionUri, verificationInfo.id)
 
-        // 3. Get the message to display.
+        // 2. Get the message to display.
         val message = transactionMessage(verificationInfo.transactionInfo)
 
-        // 4. Construct the factor that is used to look up the private key from the Keychain.
+        // 3. Construct the factor that is used to look up the private key from the Keychain.
         val methodInfo = verificationInfo.methodInfo.firstOrNull() ?: return null
 
-        // 5. Construct the transaction context information into additional data.
-        val additionalData = createAdditionalData(verificationInfo.transactionInfo)
+        // 4. Construct the transaction context information into additional data.
+        val additionalData = createAdditionalData(verificationInfo)
 
         return PendingTransactionInfo(
             id = verificationInfo.id,
@@ -357,66 +631,130 @@ class CloudAuthenticatorService(
             factorID = UUID.fromString(methodInfo.id) ?: UUID.randomUUID(),
             factorType = methodInfo.subType,
             dataToSign = verificationInfo.transactionInfo,
-            timeStamp = verificationInfo.creationTime,
+            creationTime = verificationInfo.creationTime,
+            expiryTime = verificationInfo.expiryTime,
             additionalData = additionalData
         )
     }
 
-    private fun createAdditionalData(transactionInfo: String): Map<TransactionAttribute, String> {
+    /**
+     * Calculates a correlation value from a transaction ID.
+     *
+     * The correlation value is a 2-digit number (00-99) derived from the transaction ID
+     * by taking the first 8 characters, parsing them as hexadecimal, and calculating
+     * modulo 100. This value is used to help users verify they are approving the correct
+     * transaction by matching it with a value displayed in the requesting application.
+     *
+     * @param transactionId The transaction ID to calculate the correlation value from
+     * @return A 2-digit string representation of the correlation value (00-99),
+     *         or "00" if calculation fails
+     */
+    private fun calculateCorrelationValue(transactionId: String): String {
+        return try {
+            // Take first 8 characters of transaction ID
+            val shortTransactionId = transactionId.substring(0, minOf(transactionId.length, 8))
+            // Parse as hexadecimal and calculate modulo 100
+            val correlationValue = shortTransactionId.toBigInteger(16).mod(100.toBigInteger())
+            
+            // Format with leading zero if less than 10
+            if (correlationValue > 9.toBigInteger()) {
+                correlationValue.toString()
+            } else {
+                "0${correlationValue}"
+            }
+        } catch (e: Exception) {
+            "00"
+        }
+    }
+
+    /**
+     * Creates a map of transaction attributes from verification information.
+     *
+     * This method extracts and categorizes transaction data into well-known attributes
+     * (IP address, user agent, type, location, etc.) and custom attributes.
+     *
+     * Uses kotlinx.serialization for type-safe parsing instead of org.json.
+     *
+     * @param verificationInfo The verification information containing transaction data
+     * @return A map of transaction attributes with their values
+     */
+    private fun createAdditionalData(verificationInfo: TransactionResult.VerificationInfo): Map<TransactionAttribute, String> {
         val result: MutableMap<TransactionAttribute, String> = mutableMapOf()
 
-        // Add the default type (of request) to the result.  Might be overridden if specified in additionalData.
-        result.putIfAbsent(TransactionAttribute.Type, "PendingRequestTypeDefault")
+        // Add the default type (of request) to the result. Might be overridden if specified in additionalData.
+        result[TransactionAttribute.Type] = "Default request"
 
-        JSONObject(transactionInfo).let { transactionData ->
-            transactionData.has("originIpAddress").let {
-                result[TransactionAttribute.IPAddress] =
-                    transactionData.optString("originIpAddress")
-                transactionData.remove("originIpAddress")
-            }
+        // Handle correlation from VerificationInfo
+        if (verificationInfo.correlationEnabled) {
+            result[TransactionAttribute.Correlation] = verificationInfo.correlationValue
+                ?: calculateCorrelationValue(verificationInfo.id)
+        }
 
-            transactionData.has("originUserAgent").let {
-                result[TransactionAttribute.UserAgent] =
-                    transactionData.optString("originUserAgent")
-                transactionData.remove("originUserAgent")
-            }
+        // Parse transaction data using kotlinx.serialization with Result type
+        val transactionData = runCatching {
+            DefaultJson.decodeFromString<com.ibm.security.verifysdk.mfa.model.cloud.TransactionData>(
+                verificationInfo.transactionInfo
+            )
+        }.getOrElse { e ->
+            Log.w(TAG, "Failed to parse transaction data from JSON", e)
+            return result
+        }
 
-            transactionData.has("additionalData").let {
-                val additionalData = JSONArray(transactionData.optString("additionalData"))
-                val indicesToRemove = mutableListOf<Int>()
+        // Extract standard fields
+        transactionData.originIpAddress?.let {
+            result[TransactionAttribute.IPAddress] = it
+        }
+        
+        transactionData.originUserAgent?.let {
+            result[TransactionAttribute.UserAgent] = it
+        }
 
-                for (i in 0 until additionalData.length()) {
-                    val item = additionalData.getJSONObject(i)
-                    val name = item.optString("name")
-
-                    if (name.equals("type")) {
-                        result[TransactionAttribute.Type] = item.optString("value")
-                        indicesToRemove.add(i)
-                    } else if (name.equals("originLocation")) {
-                        result[TransactionAttribute.Location] = item.optString("value")
-                        indicesToRemove.add(i)
-                    } else if (name.equals("imageURL")) {
-                        result[TransactionAttribute.Image] = item.optString("value")
-                        indicesToRemove.add(i)
-                    }
+        // Process additional data items
+        val customData = transactionData.additionalData?.filterNot { item ->
+            when (item.name) {
+                "type" -> {
+                    result[TransactionAttribute.Type] = item.value
+                    true // Remove from custom data
                 }
-
-                for (index in indicesToRemove.reversed()) {
-                    additionalData.remove(index)
+                "originLocation" -> {
+                    result[TransactionAttribute.Location] = item.value
+                    true // Remove from custom data
                 }
-
-                if (additionalData.length() > 0) {
-                    result[TransactionAttribute.Custom] = additionalData.toString()
+                "imageURL" -> {
+                    result[TransactionAttribute.Image] = item.value
+                    true // Remove from custom data
                 }
+                "denyReasonEnabled" -> {
+                    result[TransactionAttribute.DenyReason] = item.value
+                    true // Remove from custom data
+                }
+                else -> false // Keep in custom data
             }
+        }
+
+        // Add remaining custom data as JSON array
+        if (!customData.isNullOrEmpty()) {
+            result[TransactionAttribute.Custom] = DefaultJson.encodeToString(customData)
         }
 
         return result
     }
 
+    /**
+     * Extracts the transaction message from the transaction data JSON string.
+     *
+     * Uses kotlinx.serialization for type-safe parsing instead of org.json.
+     *
+     * @param value The JSON string containing transaction data
+     * @return The message string, or "PendingRequestMessageDefault" if not found or parsing fails
+     */
     private fun transactionMessage(value: String): String {
-        JSONObject(value).let {
-            return it.optString("message", "PendingRequestMessageDefault")
+        return try {
+            val data = DefaultJson.decodeFromString<com.ibm.security.verifysdk.mfa.model.cloud.TransactionData>(value)
+            data.message ?: "PendingRequestMessageDefault"
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to parse transaction message from JSON", e)
+            "PendingRequestMessageDefault"
         }
     }
 }

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudAuthenticatorService.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudAuthenticatorService.kt
@@ -690,12 +690,12 @@ class CloudAuthenticatorService(
                 ?: calculateCorrelationValue(verificationInfo.id)
         }
 
-        // Parse transaction data using kotlinx.serialization with Result type
-        val transactionData = runCatching {
+        // Parse transaction data using kotlinx.serialization
+        val transactionData = try {
             DefaultJson.decodeFromString<com.ibm.security.verifysdk.mfa.model.cloud.TransactionData>(
                 verificationInfo.transactionInfo
             )
-        }.getOrElse { e ->
+        } catch (e: Exception) {
             Log.w(TAG, "Failed to parse transaction data from JSON", e)
             return result
         }

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorService.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorService.kt
@@ -40,20 +40,75 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
 import org.slf4j.LoggerFactory
 import java.net.URL
 import java.util.UUID
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
+/**
+ * Immutable on-premise MFA authenticator service.
+ *
+ * ## Design Philosophy
+ * This service is an **immutable value object** that represents a snapshot of authenticator
+ * state at a specific point in time, consistent with CloudAuthenticatorService design.
+ *
+ * ## Lifecycle Pattern
+ * ```kotlin
+ * // 1. Create service with current token
+ * val service = OnPremiseAuthenticatorService(
+ *     _accessToken = authenticator.token.accessToken,
+ *     _refreshUri = authenticator.refreshUri,
+ *     _transactionUri = authenticator.transactionUri,
+ *     _clientId = authenticator.clientId,
+ *     _authenticatorId = authenticator.id,
+ *     httpClient = NetworkHelper.getInstance,
+ *     _ignoreSslCertificate = authenticator.ignoreSslCertificate,
+ *     persistenceCallback = repository
+ * )
+ *
+ * // 2. Use service for operations
+ * service.nextTransaction()
+ * service.completeTransaction(...)
+ *
+ * // 3. If token is refreshed, create NEW service
+ * service.refreshToken(...).onSuccess { newToken ->
+ *     // This service is now obsolete!
+ *     val newService = OnPremiseAuthenticatorService(
+ *         _accessToken = newToken.accessToken,  // New token
+ *         _refreshUri = authenticator.refreshUri,
+ *         _transactionUri = authenticator.transactionUri,
+ *         _clientId = authenticator.clientId,
+ *         _authenticatorId = authenticator.id,
+ *         httpClient = NetworkHelper.getInstance,
+ *         _ignoreSslCertificate = authenticator.ignoreSslCertificate,
+ *         persistenceCallback = repository
+ *     )
+ *     // Use newService for subsequent operations
+ * }
+ * ```
+ *
+ * @property _accessToken The OAuth access token (immutable snapshot)
+ * @property _refreshUri The endpoint URL for token refresh operations
+ * @property _transactionUri The endpoint URL for transaction operations
+ * @property _clientId The OAuth client ID
+ * @property _authenticatorId The unique identifier for this authenticator
+ * @property httpClient The HTTP client for making network requests
+ * @property _ignoreSslCertificate Whether to ignore SSL certificate validation
+ * @property persistenceCallback Optional callback for automatic token persistence
+ */
 @OptIn(ExperimentalTime::class)
 class OnPremiseAuthenticatorService(
-    private var _accessToken: String,
-    private var _refreshUri: URL,
-    private var _transactionUri: URL,
-    private var _clientId: String,
-    private var _authenticatorId: String,
-    private var _ignoreSslCertificate: Boolean = false
-
+    private val _accessToken: String,
+    private val _refreshUri: URL,
+    private val _transactionUri: URL,
+    private val _clientId: String,
+    private val _authenticatorId: String,
+    internal val httpClient: HttpClient,
+    private val _ignoreSslCertificate: Boolean = false,
+    private val persistenceCallback: com.ibm.security.verifysdk.mfa.TokenPersistenceCallback? = null
 ) : MFAServiceDescriptor {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -62,8 +117,6 @@ class OnPremiseAuthenticatorService(
         explicitNulls = false
         ignoreUnknownKeys = true
     }
-
-    private lateinit var _currentPendingTransaction: PendingTransactionInfo
 
     override val accessToken: String
         get() = _accessToken
@@ -74,9 +127,6 @@ class OnPremiseAuthenticatorService(
     override val transactionUri: URL
         get() = _transactionUri
 
-    override val currentPendingTransaction: PendingTransactionInfo?
-        get() = _currentPendingTransaction
-
     override val authenticatorId: String
         get() = _authenticatorId
 
@@ -86,12 +136,25 @@ class OnPremiseAuthenticatorService(
     val ignoreSslCertificate: Boolean
         get() = _ignoreSslCertificate
 
+    /**
+     * Refreshes the OAuth token with **CRITICAL** persistence guarantees.
+     *
+     * ## ⚠️ CRITICAL: Token Persistence
+     *
+     * This method implements **BLOCKING, ATOMIC** token persistence to prevent the
+     * "hosed authenticator" scenario.
+     *
+     * ## Service Lifecycle
+     * **IMPORTANT:** This service instance becomes obsolete after token refresh.
+     * You must create a new service instance with the new token.
+     *
+     * @see CloudAuthenticatorService.refreshToken for detailed documentation
+     */
     override suspend fun refreshToken(
         refreshToken: String,
         accountName: String?,
         pushToken: String?,
-        additionalData: Map<String, Any>?,
-        httpClient: HttpClient
+        additionalData: Map<String, Any>?
     ): Result<TokenInfo> {
 
         return try {
@@ -125,13 +188,28 @@ class OnPremiseAuthenticatorService(
                 httpClient = httpClient
             )
 
-            responseToken.fold(
-                onSuccess = { tokenInfo ->
-                    Result.success(tokenInfo)
-                },
-                onFailure = { throwable ->
-                    Result.failure(throwable)
-                })
+            responseToken.also { result ->
+                // Don't mutate state - service is immutable
+                // Repository layer creates new service instance with new token
+                result.onSuccess { tokenInfo ->
+                    // CRITICAL: Persist token BEFORE returning success
+                    // This ensures token is saved BEFORE any subsequent API call that would activate it on server
+                    persistenceCallback?.let { callback ->
+                        val persistResult = callback.onTokenRefreshed(authenticatorId, tokenInfo)
+                        persistResult.onFailure { error ->
+                            log.error("CRITICAL: Token persistence failed for authenticator $_authenticatorId: ${error.message}")
+                            // Return failure if persistence fails - token refresh is not complete without persistence
+                            return Result.failure(
+                                Exception(
+                                    "Token refresh succeeded but persistence failed: ${error.message}",
+                                    error
+                                )
+                            )
+                        }
+                        log.debug("Token persisted successfully for authenticator $_authenticatorId")
+                    }
+                }
+            }
         } catch (e: Throwable) {
             Result.failure(e)
         } finally {
@@ -140,8 +218,7 @@ class OnPremiseAuthenticatorService(
     }
 
     override suspend fun nextTransaction(
-        transactionID: String?,
-        httpClient: HttpClient
+        transactionID: String?
     ): Result<NextTransactionInfo> {
 
         return try {
@@ -158,21 +235,14 @@ class OnPremiseAuthenticatorService(
                     response.bodyAsText()
                 )
                 if (transactionResult.transactions.isEmpty()) {
-                    Result.success(NextTransactionInfo(null, 0))
+                    Result.success(NextTransactionInfo(emptyList(), 0))
                 } else {
-                    createPendingTransaction(transactionResult, transactionID, httpClient).fold(
-                        onSuccess = { pendingTransactionInfo ->
-                            _currentPendingTransaction = pendingTransactionInfo
-                            Result.success(
-                                NextTransactionInfo(
-                                    pendingTransactionInfo,
-                                    transactionResult.transactions.count()
-                                )
-                            )
-                        },
-                        onFailure = { throwable ->
-                            Result.failure(throwable)
-                        }
+                    val transactions = createPendingTransactions(transactionResult, transactionID)
+                    Result.success(
+                        NextTransactionInfo(
+                            transactions,
+                            transactionResult.transactions.count()
+                        )
                     )
                 }
             } else {
@@ -186,24 +256,38 @@ class OnPremiseAuthenticatorService(
     }
 
     override suspend fun completeTransaction(
+        transaction: PendingTransactionInfo,
         userAction: UserAction,
-        signedData: String,
-        httpClient: HttpClient
+        signedData: String
     ): Result<Unit> {
 
         return try {
-            val pendingTransaction =
-                currentPendingTransaction ?: throw MFAServiceException.InvalidPendingTransaction()
+            // Validate transaction hasn't expired
+            transaction.expiryTime?.let { expiry ->
+                if (kotlin.time.Clock.System.now() > expiry) {
+                    return Result.failure(
+                        MFAServiceException.General("Transaction ${transaction.id} has expired at $expiry")
+                    )
+                }
+            }
 
             val data = buildJsonObject {
                 put(
                     "signedChallenge",
-                    if (userAction == UserAction.VERIFY) JsonPrimitive(signedData) else JsonNull
+                    if (userAction == UserAction.VERIFY) JsonPrimitive(signedData) else JsonPrimitive(
+                        ""
+                    )
                 )
+
+                // Add denyReason if denyReasonEnabled flag is set to "true"
+                val denyReasonEnabled = transaction.additionalData[TransactionAttribute.DenyReason]
+                if (denyReasonEnabled == "true") {
+                    put("denyReason", JsonPrimitive(userAction.toString()))
+                }
             }
 
             val response = httpClient.put {
-                url(pendingTransaction.postbackUri.toString())
+                url(transaction.postbackUri.toString())
                 accept(ContentType.Application.Json)
                 bearerAuth(accessToken)
                 setBody(TextContent(data.toString(), ContentType.Application.Json))
@@ -212,10 +296,22 @@ class OnPremiseAuthenticatorService(
             if (response.status.isSuccess()) {
                 Result.success(Unit)
             } else {
-                Result.failure(MFAServiceException.General(response.bodyAsText()))
+                Result.failure(
+                    MFAServiceException.General(
+                        "Failed to complete transaction ${transaction.id}: ${response.bodyAsText()}"
+                    )
+                )
             }
-        } catch (e: Throwable) {
-            return Result.failure(e)
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            // Don't wrap cancellation exceptions
+            throw e
+        } catch (e: Exception) {
+            Result.failure(
+                MFAServiceException.General(
+                    "Exception while completing transaction ${transaction.id}: ${e.message}",
+                    e
+                )
+            )
         }
     }
 
@@ -264,33 +360,55 @@ class OnPremiseAuthenticatorService(
         }
     }
 
+    private suspend fun createPendingTransactions(
+        transactionResult: TransactionResult,
+        transactionId: String? = null
+    ): List<PendingTransactionInfo> {
+        // Get identifiers for this authenticator
+        val identifiers = transactionResult.attributes.filter {
+            it.uri == "mmfa:request:authenticator:id" && it.values.contains(authenticatorId)
+        }
+
+        // Get all transaction IDs for this authenticator
+        val transactionIds = if (transactionId != null) {
+            // If specific transaction requested, only get that one
+            listOf(transactionId)
+        } else if (identifiers.isNotEmpty()) {
+            // Get all transactions for this authenticator
+            identifiers.map { it.transactionId }
+        } else {
+            // Fallback to all transactions
+            transactionResult.transactions.map { it.transactionId }
+        }
+
+        val now = Clock.System.now()
+
+        return transactionIds.mapNotNull { txnId ->
+            val result = createPendingTransaction(transactionResult, txnId)
+            result.getOrNull()?.let { transaction ->
+                // Filter out expired transactions
+                transaction.expiryTime?.let { expiry ->
+                    if (now > expiry) {
+                        return@mapNotNull null
+                    }
+                }
+                transaction
+            }
+        }
+    }
+
     private suspend fun createPendingTransaction(
         transactionResult: TransactionResult,
-        transactionId: String? = null,
-        httpClient: HttpClient = NetworkHelper.getInstance
+        transactionId: String
     ): Result<PendingTransactionInfo> {
 
         return try {
             log.entering()
-            /* Optional variable to hold the transaction. By default, we'll store the first transaction
-           encountered but reassign if we match the authenticatorId and/or transactionId. */
-            var transactionInfoResult =
-                transactionResult.transactions.firstOrNull { it.transactionId == transactionId }
-                    ?: transactionResult.transactions.first()
-            /* Get a list of attributesPending that contain mmfa:request:authenticator:id. */
-            val identifiers =
-                transactionResult.attributes.filter { it.uri == "mmfa:request:authenticator:id" }
-
-            if (identifiers.any { it.values.contains(authenticatorId) }) {
-                val identifier = identifiers.first { it.values.contains(authenticatorId) }
-                /* If a transactionId was passed in as a parameter, get that one, otherwise get the
-               first transaction for the authenticator. */
-                transactionInfoResult = if (transactionId != null) {
-                    transactionResult.transactions.first { it.transactionId == transactionId }
-                } else {
-                    transactionResult.transactions.first { it.transactionId == identifier.transactionId }
-                }
+            // Get the specific transaction
+            val transactionInfoResult = transactionResult.transactions.firstOrNull {
+                it.transactionId == transactionId
             }
+                ?: return Result.failure(MFAServiceException.General("Transaction not found: $transactionId"))
 
             val response = httpClient.post {
                 url(transactionInfoResult.requestUrl)
@@ -302,6 +420,19 @@ class OnPremiseAuthenticatorService(
             if (response.status.isSuccess()) {
                 val verificationInfo =
                     decoder.decodeFromString<VerificationInfo>(response.bodyAsText())
+
+                // Extract expiry time from attributesPending array
+                // Look for mmfa.transactionPending.minAgeBeforeAbort attribute
+                val expirySeconds = transactionResult.attributes
+                    .firstOrNull {
+                        it.transactionId == transactionInfoResult.transactionId &&
+                                it.uri == "mmfa.transactionPending.minAgeBeforeAbort"
+                    }
+                    ?.values?.firstOrNull()?.toLongOrNull() ?: 300L
+
+                val calculatedExpiryTime =
+                    transactionInfoResult.creationTime + expirySeconds.seconds
+
                 var dataToSign = verificationInfo.serverChallenge
                 if (transactionResult.attributes.any { it.uri == "mmfa:request:signing:attributes" }) {
                     val signingInfo =
@@ -333,7 +464,8 @@ class OnPremiseAuthenticatorService(
                         factorID = UUID(0, 0), // not used for OnPrem
                         factorType = verificationInfo.type,
                         dataToSign = dataToSign,
-                        timeStamp = transactionInfoResult.creationTime,
+                        creationTime = transactionInfoResult.creationTime,
+                        expiryTime = calculatedExpiryTime,
                         additionalData = createAdditionalData(attributeInfo)
                     )
                 )
@@ -401,13 +533,98 @@ class OnPremiseAuthenticatorService(
 //    Type("type"),
 //    Custom("custom")
 
+    /**
+     * Calculates a correlation value from a transaction ID.
+     *
+     * The correlation value is a 2-digit number (00-99) derived from the transaction ID
+     * by taking the first 8 characters, parsing them as hexadecimal, and calculating
+     * modulo 100. This value is used to help users verify they are approving the correct
+     * transaction by matching it with a value displayed in the requesting application.
+     *
+     * @param transactionId The transaction ID to calculate the correlation value from
+     * @return A 2-digit string representation of the correlation value (00-99),
+     *         or "00" if calculation fails
+     */
+    private fun calculateCorrelationValue(transactionId: String): String {
+        return try {
+            // Take first 8 characters of transaction ID
+            val shortTransactionId = transactionId.substring(0, minOf(transactionId.length, 8))
+            // Parse as hexadecimal and calculate modulo 100
+            val correlationValue = shortTransactionId.toBigInteger(16).mod(100.toBigInteger())
+
+            // Format with leading zero if less than 10
+            if (correlationValue > 9.toBigInteger()) {
+                correlationValue.toString()
+            } else {
+                "0${correlationValue}"
+            }
+        } catch (e: Exception) {
+            log.warn("Failed to calculate correlation value: ${e.message}")
+            "00"
+        }
+    }
+
     private fun createAdditionalData(attributeInfos: List<TransactionResult.AttributeInfo>): Map<TransactionAttribute, String> {
 
         return try {
             log.entering()
             val result = mutableMapOf<TransactionAttribute, String>()
+            var transactionId: String? = null
+
+            // Get transaction ID from attributes
+            attributeInfos.firstOrNull()?.let {
+                transactionId = it.transactionId
+            }
 
             attributeInfos.filter { it.uri == "mmfa:request:extras" }.forEach { attributeInfo ->
+                // Parse JSON string from values if dataType is "String"
+                if (attributeInfo.dataType.equals(
+                        "String",
+                        ignoreCase = true
+                    ) && attributeInfo.values.isNotEmpty()
+                ) {
+                    try {
+                        val jsonString = attributeInfo.values.first()
+                        val jsonElement = Json.parseToJsonElement(jsonString).jsonObject
+
+                        // Extract and handle correlationEnabled (can be Boolean or String)
+                        var isCorrelationEnabled = false
+                        jsonElement["correlationEnabled"]?.let { element ->
+                            if (element is JsonPrimitive) {
+                                isCorrelationEnabled = when {
+                                    element.isString -> element.content.toBoolean()
+                                    else -> element.content.toBoolean()
+                                }
+                            }
+                        }
+
+                        // If correlation is enabled, extract or calculate correlation value
+                        if (isCorrelationEnabled) {
+                            val correlation = jsonElement["correlationValue"]?.let { element ->
+                                if (element is JsonPrimitive) {
+                                    element.content
+                                } else null
+                            } ?: transactionId?.let { calculateCorrelationValue(it) } ?: "00"
+
+                            result[TransactionAttribute.Correlation] = correlation
+                        }
+
+                        // Extract and handle denyReasonEnabled (can be Boolean or String)
+                        jsonElement["denyReasonEnabled"]?.let { element ->
+                            if (element is JsonPrimitive) {
+                                val isDenyReasonEnabled = when {
+                                    element.isString -> element.content.toBoolean()
+                                    else -> element.content.toBoolean()
+                                }
+                                result[TransactionAttribute.DenyReason] =
+                                    isDenyReasonEnabled.toString()
+                            }
+                        }
+                    } catch (e: Exception) {
+                        log.warn("Failed to parse mmfa:request:extras JSON: ${e.message}")
+                    }
+                }
+
                 if (attributeInfo.dataType.equals("type", ignoreCase = true)) {
                     result[TransactionAttribute.Type] = attributeInfo.values.first()
                 }

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/model/cloud/TransactionResult.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/model/cloud/TransactionResult.kt
@@ -14,11 +14,28 @@ internal data class TransactionResult(
     @SerialName("total") var count: Int = 0,
     @SerialName("verifications") var verifications: List<VerificationInfo>? = null
 ) {
+    /**
+     * Contains verification information for a Cloud MFA transaction.
+     *
+     * @property id The unique identifier for this verification
+     * @property creationTime The time when this verification was created
+     * @property expiryTime The time when this verification expires. May be null if not provided
+     *                      in the API response (depends on filter parameters)
+     * @property correlationEnabled Indicates whether correlation is enabled for this transaction.
+     *                              Defaults to false if not present in the response
+     * @property correlationValue The correlation value for the transaction, typically a 2-digit
+     *                           number. May be null if not provided in the response
+     * @property transactionInfo JSON string containing transaction details and context
+     * @property methodInfo List of authentication methods available for this verification
+     */
     @OptIn(ExperimentalTime::class)
     @Serializable
     data class VerificationInfo(
         val id: String,
         val creationTime: Instant,
+        val expiryTime: Instant? = null,
+        val correlationEnabled: Boolean = false,
+        val correlationValue: String? = null,
         @SerialName("transactionData") val transactionInfo: String,
         @SerialName("authenticationMethods") val methodInfo: List<MethodInfo>
     ) {

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/model/onprem/VerificationInfo.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/model/onprem/VerificationInfo.kt
@@ -5,12 +5,27 @@
 package com.ibm.security.verifysdk.mfa.model.onprem
 
 import kotlinx.serialization.Serializable
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
+/**
+ * Contains verification information for an OnPremise MFA transaction.
+ *
+ * @property mechanism The authentication mechanism URI
+ * @property location The location URI for posting the verification response
+ * @property type The type of verification
+ * @property serverChallenge The challenge string from the server (mutable for signing operations)
+ * @property keyHandles List of key handles associated with this verification
+ * @property expiryTime The time when this verification expires. If not provided in the response,
+ *                      it will be calculated as creationTime + 300 seconds
+ */
+@OptIn(ExperimentalTime::class)
 @Serializable
 data class VerificationInfo(
     val mechanism: String,
     val location: String,
     val type: String,
     var serverChallenge: String,
-    val keyHandles: List<String>
+    val keyHandles: List<String>,
+    val expiryTime: Instant? = null
 )


### PR DESCRIPTION
## Summary
Comprehensive refactoring of MFA authenticator services (Cloud and OnPremise) with constructor injection, immutable service design, and critical token persistence.

This PR replaces #105 which was accidentally closed during branch rename. All commits and changes are preserved.

## Changes
- ✅ Constructor injection for httpClient and persistenceCallback
- ✅ Immutable service design (var → val)
- ✅ Blocking token persistence to prevent 'hosed authenticator' scenario
- ✅ Explicit transaction management (removed currentPendingTransaction)
- ✅ List-based nextTransaction API
- ✅ Model updates (PendingTransactionInfo, TransactionAttribute)
- ✅ Comprehensive test coverage (integration + unit tests)
- ✅ Demo app updated for new API

## Breaking Changes
- CloudAuthenticatorService and OnPremiseAuthenticatorService constructor signatures changed
- currentPendingTransaction property removed from MFAServiceDescriptor
- nextTransaction returns List<PendingTransactionInfo> instead of nullable single transaction
- completeTransaction requires transaction parameter
- PendingTransactionInfo.timeStamp renamed to creationTime