### PR TITLE
refactor(fido2): remove test_utils dependency and inline Json configuration

### DIFF
--- a/sdk/fido2/build.gradle.kts
+++ b/sdk/fido2/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
 }
 
@@ -20,7 +19,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.datetime)
 
-    androidTestImplementation(project(":sdk:test_utils"))
+    androidTestImplementation(project(":sdk:core"))
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.mockito.kotlin) {
         // Fix issue with byte-buddy and instrumentation tests

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AssertionOptionsTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AssertionOptionsTest.kt
@@ -1,12 +1,19 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.skyscreamer.jsonassert.JSONAssert
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class AssertionOptionsTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AssertionResultResponseTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AssertionResultResponseTest.kt
@@ -1,7 +1,7 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -9,6 +9,13 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.skyscreamer.jsonassert.JSONAssert
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class AssertionResultResponseTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AttestationConveyancePreferenceTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AttestationConveyancePreferenceTest.kt
@@ -1,11 +1,18 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.SerializationException
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class AttestationConveyancePreferenceTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AuthenticatorAssertionResponseTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AuthenticatorAssertionResponseTest.kt
@@ -1,11 +1,18 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.skyscreamer.jsonassert.JSONAssert
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class AuthenticatorAssertionResponseTest{

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AuthenticatorAttachmentTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AuthenticatorAttachmentTest.kt
@@ -1,11 +1,18 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.SerializationException
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class AuthenticatorAttachmentTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AuthenticatorAttestationResponseTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AuthenticatorAttestationResponseTest.kt
@@ -1,7 +1,7 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.MissingFieldException
 import org.junit.Assert.assertEquals
@@ -9,6 +9,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.skyscreamer.jsonassert.JSONAssert
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @OptIn(ExperimentalSerializationApi::class)
 @RunWith(AndroidJUnit4::class)

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AuthenticatorSelectionCriteriaTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AuthenticatorSelectionCriteriaTest.kt
@@ -1,13 +1,20 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.skyscreamer.jsonassert.JSONAssert
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class AuthenticatorSelectionCriteriaTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AuthenticatorTransportTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/AuthenticatorTransportTest.kt
@@ -1,11 +1,18 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.SerializationException
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class AuthenticatorTransportTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialCreationOptionsTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialCreationOptionsTest.kt
@@ -1,7 +1,7 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonObject
 import org.junit.Assert.assertEquals
@@ -11,6 +11,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.skyscreamer.jsonassert.JSONAssert
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class PublicKeyCredentialCreationOptionsTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialDescriptorTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialDescriptorTest.kt
@@ -1,7 +1,7 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.SerializationException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -9,6 +9,13 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class PublicKeyCredentialDescriptorTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialParametersTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialParametersTest.kt
@@ -1,13 +1,20 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.skyscreamer.jsonassert.JSONAssert
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class PublicKeyCredentialParametersTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialRequestOptionsTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialRequestOptionsTest.kt
@@ -1,13 +1,20 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.SerializationException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.skyscreamer.jsonassert.JSONAssert
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class PublicKeyCredentialRequestOptionsTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialRpEntityTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialRpEntityTest.kt
@@ -1,13 +1,20 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.skyscreamer.jsonassert.JSONAssert
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class PublicKeyCredentialRpEntityTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialTypeTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialTypeTest.kt
@@ -1,11 +1,18 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import org.junit.runner.RunWith
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class PublicKeyCredentialTypeTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialUserEntityTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/PublicKeyCredentialUserEntityTest.kt
@@ -1,13 +1,20 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.skyscreamer.jsonassert.JSONAssert
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class PublicKeyCredentialUserEntityTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/ResponseAssertionTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/ResponseAssertionTest.kt
@@ -1,11 +1,18 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.skyscreamer.jsonassert.JSONAssert
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class ResponseAssertionTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/ResponseAttestationTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/ResponseAttestationTest.kt
@@ -1,11 +1,18 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.skyscreamer.jsonassert.JSONAssert
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class ResponseAttestationTest {

--- a/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/UserVerificationRequirementTest.kt
+++ b/sdk/fido2/src/androidTest/java/com/ibm/security/verifysdk/fido2/model/UserVerificationRequirementTest.kt
@@ -1,11 +1,18 @@
 package com.ibm.security.verifysdk.fido2.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ibm.security.verifysdk.testutils.json
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.SerializationException
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
+
+private val json = Json {
+    encodeDefaults = true
+    explicitNulls = false
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
 @RunWith(AndroidJUnit4::class)
 class UserVerificationRequirementTest {


### PR DESCRIPTION
## What does it do
Removes the dependency on the :sdk:test_utils module from the FIDO2 SDK and inlines Json configuration directly in test files.

Changes:
- Replaces :sdk:test_utils dependency with :sdk:core in build.gradle.kts
- Removes unused jetbrains.kotlin.android plugin from build configuration
- Inlines Json configuration in all 18 FIDO2 model test files with custom serialization settings (encodeDefaults, explicitNulls, ignoreUnknownKeys, isLenient)

## Motivation and Context
This change aligns with the project's module-specific test utilities pattern established in release 3.2.0. Instead of maintaining a shared :sdk:test_utils module, each SDK module now maintains its own test configuration co-located with its tests. This provides:

- Better encapsulation - test utilities are co-located with tests
- No cross-module test dependencies
- Simpler project structure
- Each module is self-contained for testing

The inline Json configuration approach is documented in AGENTS.md as a best practice for test files that need custom serialization settings.
