### PR TITLE
chore: replace deprecated APIs with modern alternatives

### DIFF
--- a/examples/fido2_demo/src/main/java/com/ibm/security/verifysdk/fido2/demoapp/AuthenticationResultActivity.kt
+++ b/examples/fido2_demo/src/main/java/com/ibm/security/verifysdk/fido2/demoapp/AuthenticationResultActivity.kt
@@ -11,12 +11,14 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.ibm.security.verifysdk.fido2.model.AssertionResultResponse
-import io.ktor.util.decodeBase64Bytes
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 
+@OptIn(ExperimentalEncodingApi::class)
 class AuthenticationResultActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -45,11 +47,10 @@ class AuthenticationResultActivity : AppCompatActivity() {
             }
 
             credentialData?.getValue("AUTHENTICATOR_ICON")?.jsonPrimitive?.content?.let { image ->
-                val decodedString: ByteArray =
-                    image.substring(image.indexOf(",") + 1).decodeBase64Bytes()
-                val decodedByte =
-                    BitmapFactory.decodeByteArray(decodedString, 0, decodedString.size)
-                findViewById<ImageView>(R.id.imageView).setImageBitmap(decodedByte)
+                val base64String = image.substring(image.indexOf(",") + 1)
+                val decodedBytes = Base64.Default.decode(base64String)
+                val decodedBitmap = BitmapFactory.decodeByteArray(decodedBytes, 0, decodedBytes.size)
+                findViewById<ImageView>(R.id.imageView).setImageBitmap(decodedBitmap)
             }
 
             fidoLoginDetailsJson["requestData"]?.jsonObject?.get("registration")?.jsonObject?.get("nickname")?.jsonPrimitive?.let { nickname ->

--- a/sdk/adaptive/src/main/java/com/ibm/security/verifysdk/adaptive/AdaptiveContext.kt
+++ b/sdk/adaptive/src/main/java/com/ibm/security/verifysdk/adaptive/AdaptiveContext.kt
@@ -5,9 +5,8 @@
 package com.ibm.security.verifysdk.adaptive
 
 import android.content.Context
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import java.util.Date
 import java.util.UUID
@@ -19,7 +18,7 @@ import java.util.UUID
  *
  * @since 3.0.0
  */
-object AdaptiveContext : LifecycleObserver {
+object AdaptiveContext : DefaultLifecycleObserver {
     /** The session identifier for the hosting application. */
     var sessionId: String = UUID.randomUUID().toString()
 
@@ -98,8 +97,11 @@ object AdaptiveContext : LifecycleObserver {
      * the session is reset.
      */
     @Throws(Exception::class)
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
-    fun resetSession() {
+    override fun onStart(owner: LifecycleOwner) {
+        resetSession()
+    }
+
+    internal fun resetSession() {
         // Check if the session ID has expired, based on session ID interval, and the timestamp at
         // which the session ID was generated. If so, create a new session ID.
         if (Date().time - renewSessionIdTimestamp.time > renewSessionIdInterval * 1000) {


### PR DESCRIPTION
## What does it do
- Replaces deprecated Ktor decodeBase64Bytes() with Kotlin stdlib Base64.Default.decode() in FIDO2 demo
- Replaces deprecated LifecycleObserver with DefaultLifecycleObserver in Adaptive SDK
- Removes deprecated @OnLifecycleEvent annotation in favor of override fun onStart()
- Extracts resetSession() as internal function for better testability

## Motivation and context
These changes address deprecation warnings in the 3.2.0 release:

1. FIDO2 Demo: Ktor's Base64 utilities are deprecated. The Kotlin stdlib provides a native, type-safe alternative that's part of the standard library (kotlin.io.encoding.Base64).

2. Adaptive SDK: The LifecycleObserver interface with @OnLifecycleEvent annotations was deprecated in AndroidX Lifecycle 2.4.0. The modern approach uses DefaultLifecycleObserver with explicit lifecycle method overrides, providing better type safety and compile-time checking.
