### PR TITLE
Release 3.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,12 +41,12 @@ allprojects {
     }
 
     val jacksonModules = listOf(
-        "com.fasterxml.jackson.core:jackson-core:2.15.3",
-        "com.fasterxml.jackson.core:jackson-databind:2.15.3",
-        "com.fasterxml.jackson.core:jackson-annotations:2.15.3",
-        "com.fasterxml.jackson.module:jackson-module-kotlin:2.15.3",
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.3",
-        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.15.3"
+        "com.fasterxml.jackson.core:jackson-core:2.21.2",
+        "com.fasterxml.jackson.core:jackson-databind:2.21.2",
+        "com.fasterxml.jackson.core:jackson-annotations:2.21.2",
+        "com.fasterxml.jackson.module:jackson-module-kotlin:2.21.2",
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.2",
+        "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.21.2"
     )
 
     configurations.matching { it.name.contains("dokka", ignoreCase = true) }.all {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ allprojects {
     val jacksonModules = listOf(
         "com.fasterxml.jackson.core:jackson-core:2.21.2",
         "com.fasterxml.jackson.core:jackson-databind:2.21.2",
-        "com.fasterxml.jackson.core:jackson-annotations:2.21.2",
+        "com.fasterxml.jackson.core:jackson-annotations:2.21",
         "com.fasterxml.jackson.module:jackson-module-kotlin:2.21.2",
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.2",
         "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.21.2"
@@ -181,6 +181,73 @@ tasks.register("inspectLibDependencies") {
                     println("    *** Could not resolve ${config.name}: ${e.message}")
                 }
             }
+        }
+    }
+}
+
+/**
+ * List a collective, deduplicated set of all resolved external dependencies across all leaf modules.
+ *
+ * Default output format:
+ *   group:name:version
+ *     used by:
+ *       - :modulePath:configurationName
+ *
+ * Library-only output:
+ *   ./gradlew listAllModuleDependencies -PlibrariesOnly=true
+ */
+tasks.register("listAllModuleDependencies") {
+    group = "help"
+    description = "Lists all resolved external dependencies across all leaf modules and the configurations that use them."
+
+    doLast {
+        val librariesOnly = providers.gradleProperty("librariesOnly")
+            .map { it.equals("true", ignoreCase = true) }
+            .orElse(false)
+            .get()
+
+        val leafProjects = rootProject.allprojects.filter {
+            it.subprojects.isEmpty() && it.path !in listOf(
+                ":examples",
+                ":sdk"
+            )
+        }
+
+        val dependencyUsage = sortedMapOf<String, MutableSet<String>>()
+
+        leafProjects.forEach { p ->
+            val configs = p.configurations.filter { it.isCanBeResolved }
+
+            configs.forEach { config ->
+                try {
+                    config.incoming.resolutionResult.allDependencies
+                        .filterIsInstance<ResolvedDependencyResult>()
+                        .mapNotNull { it.selected.moduleVersion }
+                        .forEach { moduleVersion ->
+                            val coordinate = "${moduleVersion.group}:${moduleVersion.name}:${moduleVersion.version}"
+                            dependencyUsage
+                                .getOrPut(coordinate) { sortedSetOf() }
+                                .add("${p.path}:${config.name}")
+                        }
+                } catch (e: Exception) {
+                    println("*** Could not resolve ${p.path}:${config.name}: ${e.message}")
+                }
+            }
+        }
+
+        dependencyUsage.forEach { (dependency, usages) ->
+            println(dependency)
+            if (!librariesOnly) {
+                println("  used by:")
+                usages.forEach { usage ->
+                    println("    - $usage")
+                }
+            }
+        }
+
+        if (!librariesOnly) {
+            println()
+            println("Total unique external dependencies: ${dependencyUsage.size}")
         }
     }
 }


### PR DESCRIPTION
## What does it do?

Merges `release/3.2.0` into `main` with the current branch delta consisting of build tooling and dependency-management updates in `build.gradle.kts`.

Changes included in this PR:
- Adds aggregate dependency reporting
- Updates Dokka-related Jackson dependency forcing

## Motivation and Context

This PR is intended to bring the current `release/3.2.0` branch state into `main`.

The effective diff between `main` and `release/3.2.0` is currently limited to `build.gradle.kts`, but the changes are still useful operationally:

- The new dependency reporting task makes it easier to inspect and inventory third-party dependencies across the full multi-module repository without checking each module individually.
- The `librariesOnly` mode improves usability for scripting, compliance review, and generating dependency inventories.
- The Dokka Jackson version update reduces dependency drift in documentation-related resolution and helps mitigate exposure to the older Jackson vulnerability documented in:
  - https://github.com/advisories/GHSA-72hv-8253-57qq

This is a build-focused PR rather than an SDK API/runtime change.