### PR TITLE
chore(release): prepare 3.2.1 version and sdk config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,8 @@ plugins {
 }
 
 // used for release naming and in MFA SDK
-extra["versionName"] = "3.2.0"
-extra["versionCode"] = "118"
+extra["versionName"] = "3.2.1"
+extra["versionCode"] = "119"
 
 dependencies {
     add("implementation", enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.15.3"))

--- a/common-config-demos.gradle
+++ b/common-config-demos.gradle
@@ -1,5 +1,5 @@
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 29

--- a/common-config.gradle
+++ b/common-config.gradle
@@ -2,7 +2,7 @@ android {
     namespace = "com.ibm.security.verifysdk." + project.path.replaceFirst("^:sdk:", "").replace(":", ".")
     testNamespace = "com.ibm.security.verifysdk." + project.path.replaceFirst("^:sdk:", "").replace(":", ".") + ".test"
 
-    compileSdk = 36
+    compileSdk = 37
     buildFeatures.buildConfig = true
 
     defaultConfig {


### PR DESCRIPTION
## What does it do
- updates the SDK version to 3.2.1
- aligns shared SDK build configuration
- aligns demo build configuration

## Motivation and context
This is the release/config preparation for 3.2.1. It is kept separate from MFA runtime changes so configuration updates can be reviewed and merged independently.