### PR TITLE
fix(mfa): restore v2-compatible signature key naming

### DIFF
--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProvider.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProvider.kt
@@ -386,7 +386,7 @@ class CloudRegistrationProvider(data: String) :
             throw MFARegistrationException.InvalidAlgorithm(factor.algorithm)
         }
 
-        val keyName = "${metaData.id}.${type.name}"
+        val keyName = "${metaData.id}.${type}"
 
         // Generate the key pair with authenticationRequired = true.
         val publicKey = generateKeys(
@@ -476,7 +476,7 @@ class CloudRegistrationProvider(data: String) :
             throw MFARegistrationException.InvalidAlgorithm(factor.algorithm)
         }
 
-        val keyName = "${metaData.id}.${type.name}"
+        val keyName = "${metaData.id}.${type}"
         val isBiometric = type == EnrollableType.FACE || type == EnrollableType.FINGERPRINT
 
         // When authenticationRequired is true for a biometric key, the key is locked after

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt
@@ -256,7 +256,7 @@ class OnPremiseRegistrationProvider(data: String) :
             throw MFARegistrationException.InvalidAlgorithm(factor.algorithm)
         }
 
-        val keyName = "${authenticatorId}.${type.name}"
+        val keyName = "${authenticatorId}.${type}"
 
         // Generate the key pair with authenticationRequired = true.
         val publicKey = generateKeys(
@@ -344,7 +344,7 @@ class OnPremiseRegistrationProvider(data: String) :
             throw MFARegistrationException.InvalidAlgorithm(factor.algorithm)
         }
 
-        val keyName = "${authenticatorId}.${type.name}"
+        val keyName = "${authenticatorId}.${type}"
         val isBiometric = type == EnrollableType.FACE || type == EnrollableType.FINGERPRINT
 
         // OPT-1: When authenticationRequired is true for a biometric key, the key is locked after
@@ -391,9 +391,7 @@ class OnPremiseRegistrationProvider(data: String) :
             log.entering()
 
             val path =
-                "urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Authenticator:${
-                    EnrollableType.forIsvaEnrollment(type)
-                }Methods"
+                "urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Authenticator:${type}Methods"
             val enrollmentUrl = URL("${signatureEnrollableFactor.uri}?attributes=${path}")
 
             val requestBody = buildJsonObject {


### PR DESCRIPTION
## What does it do
- restores v2.x.x-compatible signature key alias generation
- aligns cloud and on-premise provider key naming
- isolates the 3.2.1 breaking key-name behavior change

## Motivation and context
This is the primary behavioral change in 3.2.1. It is breaking relative to 3.2.0, so it should be reviewed in isolation from other MFA compatibility changes.