### PR TITLE
refactor(mfa): normalize enrollment algorithm and factor handling

### DIFF
--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/EnrollableSignatureTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/EnrollableSignatureTest.kt
@@ -386,6 +386,6 @@ class EnrollableSignatureTest {
         assert(result.contains("biometricAuthentication=true"))
         assert(result.contains("algorithmType=HmacSHA256"))
         assert(result.contains("authenticatorId=test-auth-id"))
-        assert(result.contains("enrollableType=FACE"))
+        assert(result.contains("enrollableType=face"))
     }
 }

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/EnrollableTypeTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/EnrollableTypeTest.kt
@@ -33,15 +33,6 @@ class EnrollableTypeTest {
     }
 
     @Test
-    fun fromString_withTOTP_shouldReturnTOTP() {
-        // When
-        val result = EnrollableType.fromString("TOTP")
-
-        // Then
-        assertEquals(EnrollableType.TOTP, result)
-    }
-
-    @Test
     fun fromString_withTOTPLowercase_shouldReturnTOTP() {
         // When
         val result = EnrollableType.fromString("totp")
@@ -51,21 +42,12 @@ class EnrollableTypeTest {
     }
 
     @Test
-    fun fromString_withTOTPMixedCase_shouldReturnTOTP() {
+    fun fromString_withTOTPUppercase_shouldReturnNull() {
         // When
-        val result = EnrollableType.fromString("ToTp")
+        val result = EnrollableType.fromString("TOTP")
 
         // Then
-        assertEquals(EnrollableType.TOTP, result)
-    }
-
-    @Test
-    fun fromString_withHOTP_shouldReturnHOTP() {
-        // When
-        val result = EnrollableType.fromString("HOTP")
-
-        // Then
-        assertEquals(EnrollableType.HOTP, result)
+        assertNull(result)
     }
 
     @Test
@@ -78,30 +60,12 @@ class EnrollableTypeTest {
     }
 
     @Test
-    fun fromString_withFACE_shouldReturnFACE() {
-        // When
-        val result = EnrollableType.fromString("FACE")
-
-        // Then
-        assertEquals(EnrollableType.FACE, result)
-    }
-
-    @Test
     fun fromString_withFACELowercase_shouldReturnFACE() {
         // When
         val result = EnrollableType.fromString("face")
 
         // Then
         assertEquals(EnrollableType.FACE, result)
-    }
-
-    @Test
-    fun fromString_withFINGERPRINT_shouldReturnFINGERPRINT() {
-        // When
-        val result = EnrollableType.fromString("FINGERPRINT")
-
-        // Then
-        assertEquals(EnrollableType.FINGERPRINT, result)
     }
 
     @Test
@@ -114,21 +78,21 @@ class EnrollableTypeTest {
     }
 
     @Test
-    fun fromString_withUSER_PRESENCE_shouldReturnUSER_PRESENCE() {
+    fun fromString_withUserPresenceCamelCase_shouldReturnUSER_PRESENCE() {
         // When
-        val result = EnrollableType.fromString("USER_PRESENCE")
+        val result = EnrollableType.fromString("userPresence")
 
         // Then
         assertEquals(EnrollableType.USER_PRESENCE, result)
     }
 
     @Test
-    fun fromString_withUSER_PRESENCELowercase_shouldReturnUSER_PRESENCE() {
+    fun fromString_withUserPresenceUppercase_shouldReturnNull() {
         // When
-        val result = EnrollableType.fromString("user_presence")
+        val result = EnrollableType.fromString("USER_PRESENCE")
 
         // Then
-        assertEquals(EnrollableType.USER_PRESENCE, result)
+        assertNull(result)
     }
 
     @Test
@@ -158,59 +122,6 @@ class EnrollableTypeTest {
         assertNull(result)
     }
 
-    @Test
-    fun forIsvaEnrollment_withTOTP_shouldReturnLowercase() {
-        // When
-        val result = EnrollableType.forIsvaEnrollment(EnrollableType.TOTP)
-
-        // Then
-        assertEquals("totp", result)
-    }
-
-    @Test
-    fun forIsvaEnrollment_withHOTP_shouldReturnLowercase() {
-        // When
-        val result = EnrollableType.forIsvaEnrollment(EnrollableType.HOTP)
-
-        // Then
-        assertEquals("hotp", result)
-    }
-
-    @Test
-    fun forIsvaEnrollment_withFACE_shouldReturnLowercase() {
-        // When
-        val result = EnrollableType.forIsvaEnrollment(EnrollableType.FACE)
-
-        // Then
-        assertEquals("face", result)
-    }
-
-    @Test
-    fun forIsvaEnrollment_withFINGERPRINT_shouldReturnLowercase() {
-        // When
-        val result = EnrollableType.forIsvaEnrollment(EnrollableType.FINGERPRINT)
-
-        // Then
-        assertEquals("fingerprint", result)
-    }
-
-    @Test
-    fun forIsvaEnrollment_withUSER_PRESENCE_shouldReturnUserPresence() {
-        // When
-        val result = EnrollableType.forIsvaEnrollment(EnrollableType.USER_PRESENCE)
-
-        // Then
-        assertEquals("userPresence", result)
-    }
-
-    @Test
-    fun forIsvaEnrollment_withNull_shouldReturnEmptyString() {
-        // When
-        val result = EnrollableType.forIsvaEnrollment(null)
-
-        // Then
-        assertEquals("", result)
-    }
 
     @Test
     fun name_shouldReturnEnumName() {
@@ -258,30 +169,31 @@ class EnrollableTypeTest {
     }
 
     @Test
-    fun toString_shouldReturnEnumName() {
-        // Then
-        assertEquals("TOTP", EnrollableType.TOTP.toString())
-        assertEquals("HOTP", EnrollableType.HOTP.toString())
-        assertEquals("FACE", EnrollableType.FACE.toString())
-        assertEquals("FINGERPRINT", EnrollableType.FINGERPRINT.toString())
-        assertEquals("USER_PRESENCE", EnrollableType.USER_PRESENCE.toString())
+    fun toString_shouldReturnCorrectFormat() {
+        // Then - matches v2 SubType.toString() format
+        assertEquals("totp", EnrollableType.TOTP.toString())
+        assertEquals("hotp", EnrollableType.HOTP.toString())
+        assertEquals("face", EnrollableType.FACE.toString())
+        assertEquals("fingerprint", EnrollableType.FINGERPRINT.toString())
+        assertEquals("userPresence", EnrollableType.USER_PRESENCE.toString())
     }
 
     @Test
-    fun fromString_roundTrip_shouldPreserveValue() {
+    fun fromString_toString_roundTrip_shouldPreserveValue() {
         // Given
         val types = EnrollableType.values()
 
-        // When/Then
+        // When/Then - toString() returns the format that fromString() expects
         for (type in types) {
-            val result = EnrollableType.fromString(type.name)
+            val stringValue = type.toString()
+            val result = EnrollableType.fromString(stringValue)
             assertEquals(type, result)
         }
     }
 
     @Test
-    fun forIsvaEnrollment_allTypes_shouldReturnValidStrings() {
-        // Given
+    fun toString_allTypes_shouldMatchV2Format() {
+        // Given - Expected format matches v2 SubType.toString()
         val expectedMappings = mapOf(
             EnrollableType.TOTP to "totp",
             EnrollableType.HOTP to "hotp",
@@ -292,7 +204,7 @@ class EnrollableTypeTest {
 
         // When/Then
         for ((type, expected) in expectedMappings) {
-            val result = EnrollableType.forIsvaEnrollment(type)
+            val result = type.toString()
             assertEquals(expected, result)
         }
     }

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/MFARegistrationExceptionTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/MFARegistrationExceptionTest.kt
@@ -86,7 +86,7 @@ class MFARegistrationExceptionTest {
         val exception = MFARegistrationException.NoEnrollableFactors(EnrollableType.USER_PRESENCE, cause)
 
         // Then
-        assertTrue(exception.message?.contains(EnrollableType.USER_PRESENCE.toString()) ?: false)
+        assertTrue(exception.message?.contains(EnrollableType.USER_PRESENCE.name) ?: false)
         assertEquals(cause, exception.cause)
     }
 

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/EnrollableType.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/EnrollableType.kt
@@ -11,19 +11,22 @@ enum class EnrollableType {
     FINGERPRINT,
     USER_PRESENCE;
 
+    override fun toString(): String {
+        return when (this) {
+            USER_PRESENCE -> "userPresence"
+            else -> name.lowercase()
+        }
+    }
+
     companion object {
         fun fromString(type: String): EnrollableType? {
-            return try {
-                valueOf(type.uppercase())
-            } catch (e: IllegalArgumentException) {
-                null
-            }
-        }
-
-        internal fun forIsvaEnrollment(type: EnrollableType?):String {
             return when (type) {
-                USER_PRESENCE -> "userPresence"
-                else -> type?.name?.lowercase() ?: ""
+                "fingerprint" -> FINGERPRINT
+                "face" -> FACE
+                "userPresence" -> USER_PRESENCE
+                "totp" -> TOTP
+                "hotp" -> HOTP
+                else -> null
             }
         }
     }

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/HashAlgorithmType.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/HashAlgorithmType.kt
@@ -11,7 +11,20 @@ import java.util.Locale
  * Values indicating the type of hash algorithm to use. Instantiates an instance of the conforming
  * type from a string representation.
  *
- * @param rawValue The name of the algorithm.
+ * The HashAlgorithmType enum represents the underlying hash algorithm (SHA-1, SHA-256, SHA-384,
+ * SHA-512) in an abstract way, independent of the cryptographic operation (HMAC vs RSA). This
+ * design allows the SDK to:
+ * - Store a single enum value that represents the hash algorithm
+ * - Convert to the appropriate format for different contexts (HMAC for TOTP, RSA for biometric)
+ * - Support both symmetric (HMAC) and asymmetric (RSA) operations with the same enum
+ *
+ * The enum accepts multiple string formats via [fromString] (e.g., "SHA256", "HmacSHA256",
+ * "RSASHA256", "SHA256withRSA") and provides conversion methods:
+ * - [toString] returns the HMAC format (e.g., "HmacSHA256")
+ * - [forSigning] returns the RSA signing format (e.g., "SHA256withRSA")
+ * - [toIsvFormat] returns the IBM Verify SaaS format (e.g., "RSASHA256")
+ *
+ * @param rawValue The default string representation of the algorithm (HMAC format).
  */
 @Serializable(with = HashAlgorithmTypeSerializer::class)
 enum class HashAlgorithmType(private val rawValue: String) {


### PR DESCRIPTION
## What does it do
- normalizes factor parsing and enrollment-related algorithm handling
- keeps enum and normalization updates grouped together
- separates normalization work from provider-specific compatibility changes

## Motivation and context
These changes are related to factor and algorithm normalization behavior. Keeping them on a dedicated branch makes the registration providers and payload fixes easier to review.