### PR TITLE
test(mfa): cover registration provider compatibility changes

### DIFF
--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProviderTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProviderTest.kt
@@ -1111,7 +1111,7 @@ class CloudRegistrationProviderTest {
                     "authenticatorId": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd",
                     "additionalData": [{
                         "name": "name",
-                        "value": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd.FINGERPRINT"
+                        "value": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd.fingerprint"
                     }],
                     "algorithm": "RSASHA256"
                 },
@@ -1245,7 +1245,7 @@ class CloudRegistrationProviderTest {
                     "authenticatorId": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd",
                     "additionalData": [{
                         "name": "name",
-                        "value": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd.FACE"
+                        "value": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd.face"
                     }],
                     "algorithm": "RSASHA256"
                 },
@@ -1379,7 +1379,7 @@ class CloudRegistrationProviderTest {
                     "authenticatorId": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd",
                     "additionalData": [{
                         "name": "name",
-                        "value": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd.USER_PRESENCE"
+                        "value": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd.userPresence"
                     }],
                     "algorithm": "RSASHA256"
                 },

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorIntegrationTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorIntegrationTest.kt
@@ -80,7 +80,7 @@ class OnPremiseAuthenticatorIntegrationTest {
                             "urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Authenticator": {
                               "userPresenceMethods": [{
                                 "id": "uuid-test-factor-id-001",
-                                "keyHandle": "test-authenticator-id-001.USER_PRESENCE",
+                                "keyHandle": "test-authenticator-id-001.userPresence",
                                 "authenticator": "test-authenticator-id-001",
                                 "enabled": true,
                                 "algorithm": "SHA512withRSA"
@@ -137,7 +137,7 @@ class OnPremiseAuthenticatorIntegrationTest {
                             "urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Authenticator": {
                               "fingerprintMethods": [{
                                 "id": "uuid-test-factor-id-002",
-                                "keyHandle": "test-authenticator-id-001.FINGERPRINT",
+                                "keyHandle": "test-authenticator-id-001.fingerprint",
                                 "authenticator": "test-authenticator-id-001",
                                 "enabled": true,
                                 "algorithm": "SHA512withRSA"
@@ -348,7 +348,7 @@ class OnPremiseAuthenticatorIntegrationTest {
                           "location": "/mga/sps/apiauthsvc?StateId=test_state_token_001",
                           "type": "user_presence",
                           "serverChallenge": "test_server_challenge_001",
-                          "keyHandles": ["test-authenticator-id-001.USER_PRESENCE"]
+                          "keyHandles": ["test-authenticator-id-001.userPresence"]
                         }
                         """.trimIndent(),
                         status = HttpStatusCode.OK,


### PR DESCRIPTION
## What does it do
- adds provider-focused MFA test coverage for 3.2.1
- validates registration compatibility behavior
- covers on-premise integration expectations

## Motivation and context
These tests validate the provider-side changes introduced for 3.2.1 and should remain separate from implementation branches to keep the review scope clear.