### PR TITLE
docs(release): add 3.2.1 release notes

### DIFF
--- a/docs/releases/3.2.1.md
+++ b/docs/releases/3.2.1.md
@@ -1,0 +1,171 @@
+# IBM Verify SDK for Android - Release 3.2.1
+
+## Overview
+
+Version 3.2.1 is a patch release focused on MFA registration compatibility, device attribute handling, and platform configuration updates. This release improves interoperability with IBM Verify Identity Access on-premise environments and refines device metadata collected during registration and token refresh flows.
+
+## 🚨 Breaking Changes
+
+### 1. MFA SDK - Signature Key Name Generation Change
+
+**Impact: MEDIUM**
+
+Signature-based MFA enrollment now uses revised key name generation to restore alignment with the v2.x.x behavior.
+
+#### Change:
+In 3.2.0, some enrollment paths generated key names using newer internal conventions. In 3.2.1, key name generation has been corrected to align with the authenticator/factor naming expected by existing IBM Verify deployments and by the v2.x.x SDK line.
+
+#### Example:
+For an authenticator with ID `12345678-1234-1234-1234-123456789abc`:
+
+- **3.2.0-style key name:** `12345678-1234-1234-1234-123456789abc.FINGERPRINT`
+- **3.2.1 / v2.x.x-style key name:** `12345678-1234-1234-1234-123456789abc.fingerprint`
+
+For user presence enrollment:
+
+- **3.2.0-style key name:** `12345678-1234-1234-1234-123456789abc.USER_PRESENCE`
+- **3.2.1 / v2.x.x-style key name:** `12345678-1234-1234-1234-123456789abc.userPresence`
+
+#### Impact:
+- Existing registrations created with 3.2.0 may use different key aliases than registrations created with 3.2.1
+- Applications relying on previously generated 3.2.0 key names should review biometric and user-presence enrollment behavior after upgrade
+- This is a behavioral breaking change relative to 3.2.0, but it restores compatibility with the historical v2.x.x convention
+
+#### Migration Notes:
+- New registrations created on 3.2.1 will use the corrected key name format
+- If an application persisted assumptions about 3.2.0-generated key aliases, those assumptions should be updated
+- Re-enrollment may be required for factors created under the 3.2.0 naming behavior in some upgrade scenarios
+
+## ✨ Key Changes
+
+### 2. MFA SDK - On-Premise Registration Compatibility Improvements
+
+The MFA SDK now better aligns on-premise registration and refresh flows with IBM Verify Identity Access expectations.
+
+#### Improvements:
+- Uses `device_rooted` for snake_case device security attributes sent to on-premise environments
+- Continues to use `deviceInsecure` for camelCase cloud-oriented payloads
+- Sends `tenant_id` consistently during on-premise registration and token refresh flows
+- Improves alignment with real IVIA network traces validated in integration testing
+
+#### Impact:
+- Better compatibility with IBM Verify Identity Access deployments
+- More predictable device attribute payloads during registration
+- Reduced risk of server-side attribute mismatches in on-premise flows
+
+### 3. MFA SDK - Device Attribute Refinements
+
+`MFAAttributeInfo` has been refined to improve correctness and runtime behavior.
+
+#### Improvements:
+- `deviceName` now prefers the user-configured device name from system settings and falls back to `Build.MODEL`
+- Root detection results are cached briefly to avoid repeated expensive checks
+- Static device/application attributes are cached, while `deviceId` remains refreshed from persistent storage for migration safety
+- Snake_case and camelCase attribute dictionaries remain explicitly supported for different backend expectations
+
+#### Impact:
+- Better fidelity of device metadata reported to backend services
+- Reduced overhead during repeated MFA operations
+- Safer handling of persisted device identifiers across migration scenarios
+
+### 4. MFA SDK - Registration Enrollment Updates
+
+Cloud and on-premise registration providers were updated in the areas that use signature-based factor enrollment, including biometric and user-presence factors.
+
+#### Improvements:
+- Corrects signature key name generation to align with v2.x.x behavior
+- Keeps pending biometric enrollment state when biometric authentication is required before enrollment can complete
+- Reuses normalized signing algorithm handling when processing server-provided factor metadata
+- Preserves clearer error reporting when an invalid or unsupported hash algorithm is returned
+
+#### Impact:
+- More reliable biometric enrollment flows when authentication is required
+- Corrected factor key alias generation for new enrollments
+- Clearer failure modes when server-provided enrollment metadata is invalid
+
+### 5. Build and Platform Configuration Updates
+
+Project configuration has been updated for the 3.2.1 release line.
+
+#### Changes:
+- SDK version updated to `3.2.1`
+- Android `compileSdk` updated to 37 for SDK modules and demo applications
+- Java/Kotlin toolchain configuration remains on Java 17
+
+## 🔧 Improvements
+
+### MFA SDK
+1. **Device Attribute Mapping**
+   - Distinguishes cloud and on-premise security attribute naming
+   - Preserves mixed-type attribute values while supporting downstream serialization needs
+
+2. **Registration Providers**
+   - Corrected v2.x.x-compatible signature key name generation for new enrollments
+   - Improved handling of biometric authentication-required enrollment state
+
+3. **Algorithm Handling**
+   - Continues supporting multiple input formats for hash algorithm parsing
+   - Centralizes conversion to signing and IBM Verify SaaS formats
+
+### Build Configuration
+1. **Platform Alignment**
+   - `compileSdk` increased to 37
+   - Release version set to 3.2.1
+
+## 🧪 Testing
+
+This release includes continued MFA test coverage updates, including validation for:
+
+- `MFAAttributeInfo` camelCase and snake_case dictionary output
+- `device_rooted` mapping for on-premise payloads
+- `HashAlgorithmType` parsing and signing conversions
+- `EnrollableType` serialization and parsing behavior
+- On-premise integration scenarios based on sanitized real network traces
+- Token refresh and transaction flow behavior for on-premise authenticators
+
+## 📚 Documentation
+
+### New Documentation Files
+- `docs/releases/3.2.1.md` - This release document
+
+## 🔄 Upgrade Notes
+
+Update your dependency declarations to 3.2.1:
+
+```kotlin
+dependencies {
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-authentication:3.2.1")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-mfa:3.2.1")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-core:3.2.1")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-fido2:3.2.1")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-adaptive:3.2.1")
+}
+```
+
+## 🐛 Known Issues
+
+None at this time.
+
+## 📝 Additional Notes
+
+- This is a patch release with a targeted behavioral breaking change in MFA key name generation
+- The primary value is improved MFA interoperability, attribute handling, and restored v2.x.x key alias compatibility
+- On-premise MFA consumers should upgrade to benefit from the refined payload mappings
+
+## 🔗 Links
+
+- [GitHub Release](https://github.com/ibm-verify/verify-sdk-android/releases/tag/3.2.1)
+- [Repository](https://github.com/ibm-verify/verify-sdk-android)
+- [JitPack](https://jitpack.io/#ibm-verify/verify-sdk-android/3.2.1)
+
+## 📧 Support
+
+For issues, questions, or contributions, please visit:
+- [GitHub Issues](https://github.com/ibm-verify/verify-sdk-android/issues)
+- [Contributing Guide](../../CONTRIBUTING.md)
+
+---
+
+**Release Date:** May 2026  
+**Version:** 3.2.1  
+**Previous Version:** 3.2.0


### PR DESCRIPTION
## What does it do
- adds the 3.2.1 release notes

## Motivation and context
Documentation should be merged after implementation and tests are stable so the final release notes match the accepted release content.