### PR TITLE
Release 3.2.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,8 @@ plugins {
 }
 
 // used for release naming and in MFA SDK
-extra["versionName"] = "3.2.0"
-extra["versionCode"] = "118"
+extra["versionName"] = "3.2.1"
+extra["versionCode"] = "119"
 
 dependencies {
     add("implementation", enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.15.3"))

--- a/common-config-demos.gradle
+++ b/common-config-demos.gradle
@@ -1,5 +1,5 @@
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 29

--- a/common-config.gradle
+++ b/common-config.gradle
@@ -2,7 +2,7 @@ android {
     namespace = "com.ibm.security.verifysdk." + project.path.replaceFirst("^:sdk:", "").replace(":", ".")
     testNamespace = "com.ibm.security.verifysdk." + project.path.replaceFirst("^:sdk:", "").replace(":", ".") + ".test"
 
-    compileSdk = 36
+    compileSdk = 37
     buildFeatures.buildConfig = true
 
     defaultConfig {

--- a/docs/releases/3.2.1.md
+++ b/docs/releases/3.2.1.md
@@ -1,0 +1,171 @@
+# IBM Verify SDK for Android - Release 3.2.1
+
+## Overview
+
+Version 3.2.1 is a patch release focused on MFA registration compatibility, device attribute handling, and platform configuration updates. This release improves interoperability with IBM Verify Identity Access on-premise environments and refines device metadata collected during registration and token refresh flows.
+
+## 🚨 Breaking Changes
+
+### 1. MFA SDK - Signature Key Name Generation Change
+
+**Impact: MEDIUM**
+
+Signature-based MFA enrollment now uses revised key name generation to restore alignment with the v2.x.x behavior.
+
+#### Change:
+In 3.2.0, some enrollment paths generated key names using newer internal conventions. In 3.2.1, key name generation has been corrected to align with the authenticator/factor naming expected by existing IBM Verify deployments and by the v2.x.x SDK line.
+
+#### Example:
+For an authenticator with ID `12345678-1234-1234-1234-123456789abc`:
+
+- **3.2.0-style key name:** `12345678-1234-1234-1234-123456789abc.FINGERPRINT`
+- **3.2.1 / v2.x.x-style key name:** `12345678-1234-1234-1234-123456789abc.fingerprint`
+
+For user presence enrollment:
+
+- **3.2.0-style key name:** `12345678-1234-1234-1234-123456789abc.USER_PRESENCE`
+- **3.2.1 / v2.x.x-style key name:** `12345678-1234-1234-1234-123456789abc.userPresence`
+
+#### Impact:
+- Existing registrations created with 3.2.0 may use different key aliases than registrations created with 3.2.1
+- Applications relying on previously generated 3.2.0 key names should review biometric and user-presence enrollment behavior after upgrade
+- This is a behavioral breaking change relative to 3.2.0, but it restores compatibility with the historical v2.x.x convention
+
+#### Migration Notes:
+- New registrations created on 3.2.1 will use the corrected key name format
+- If an application persisted assumptions about 3.2.0-generated key aliases, those assumptions should be updated
+- Re-enrollment may be required for factors created under the 3.2.0 naming behavior in some upgrade scenarios
+
+## ✨ Key Changes
+
+### 2. MFA SDK - On-Premise Registration Compatibility Improvements
+
+The MFA SDK now better aligns on-premise registration and refresh flows with IBM Verify Identity Access expectations.
+
+#### Improvements:
+- Uses `device_rooted` for snake_case device security attributes sent to on-premise environments
+- Continues to use `deviceInsecure` for camelCase cloud-oriented payloads
+- Sends `tenant_id` consistently during on-premise registration and token refresh flows
+- Improves alignment with real IVIA network traces validated in integration testing
+
+#### Impact:
+- Better compatibility with IBM Verify Identity Access deployments
+- More predictable device attribute payloads during registration
+- Reduced risk of server-side attribute mismatches in on-premise flows
+
+### 3. MFA SDK - Device Attribute Refinements
+
+`MFAAttributeInfo` has been refined to improve correctness and runtime behavior.
+
+#### Improvements:
+- `deviceName` now prefers the user-configured device name from system settings and falls back to `Build.MODEL`
+- Root detection results are cached briefly to avoid repeated expensive checks
+- Static device/application attributes are cached, while `deviceId` remains refreshed from persistent storage for migration safety
+- Snake_case and camelCase attribute dictionaries remain explicitly supported for different backend expectations
+
+#### Impact:
+- Better fidelity of device metadata reported to backend services
+- Reduced overhead during repeated MFA operations
+- Safer handling of persisted device identifiers across migration scenarios
+
+### 4. MFA SDK - Registration Enrollment Updates
+
+Cloud and on-premise registration providers were updated in the areas that use signature-based factor enrollment, including biometric and user-presence factors.
+
+#### Improvements:
+- Corrects signature key name generation to align with v2.x.x behavior
+- Keeps pending biometric enrollment state when biometric authentication is required before enrollment can complete
+- Reuses normalized signing algorithm handling when processing server-provided factor metadata
+- Preserves clearer error reporting when an invalid or unsupported hash algorithm is returned
+
+#### Impact:
+- More reliable biometric enrollment flows when authentication is required
+- Corrected factor key alias generation for new enrollments
+- Clearer failure modes when server-provided enrollment metadata is invalid
+
+### 5. Build and Platform Configuration Updates
+
+Project configuration has been updated for the 3.2.1 release line.
+
+#### Changes:
+- SDK version updated to `3.2.1`
+- Android `compileSdk` updated to 37 for SDK modules and demo applications
+- Java/Kotlin toolchain configuration remains on Java 17
+
+## 🔧 Improvements
+
+### MFA SDK
+1. **Device Attribute Mapping**
+   - Distinguishes cloud and on-premise security attribute naming
+   - Preserves mixed-type attribute values while supporting downstream serialization needs
+
+2. **Registration Providers**
+   - Corrected v2.x.x-compatible signature key name generation for new enrollments
+   - Improved handling of biometric authentication-required enrollment state
+
+3. **Algorithm Handling**
+   - Continues supporting multiple input formats for hash algorithm parsing
+   - Centralizes conversion to signing and IBM Verify SaaS formats
+
+### Build Configuration
+1. **Platform Alignment**
+   - `compileSdk` increased to 37
+   - Release version set to 3.2.1
+
+## 🧪 Testing
+
+This release includes continued MFA test coverage updates, including validation for:
+
+- `MFAAttributeInfo` camelCase and snake_case dictionary output
+- `device_rooted` mapping for on-premise payloads
+- `HashAlgorithmType` parsing and signing conversions
+- `EnrollableType` serialization and parsing behavior
+- On-premise integration scenarios based on sanitized real network traces
+- Token refresh and transaction flow behavior for on-premise authenticators
+
+## 📚 Documentation
+
+### New Documentation Files
+- `docs/releases/3.2.1.md` - This release document
+
+## 🔄 Upgrade Notes
+
+Update your dependency declarations to 3.2.1:
+
+```kotlin
+dependencies {
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-authentication:3.2.1")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-mfa:3.2.1")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-core:3.2.1")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-fido2:3.2.1")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-adaptive:3.2.1")
+}
+```
+
+## 🐛 Known Issues
+
+None at this time.
+
+## 📝 Additional Notes
+
+- This is a patch release with a targeted behavioral breaking change in MFA key name generation
+- The primary value is improved MFA interoperability, attribute handling, and restored v2.x.x key alias compatibility
+- On-premise MFA consumers should upgrade to benefit from the refined payload mappings
+
+## 🔗 Links
+
+- [GitHub Release](https://github.com/ibm-verify/verify-sdk-android/releases/tag/3.2.1)
+- [Repository](https://github.com/ibm-verify/verify-sdk-android)
+- [JitPack](https://jitpack.io/#ibm-verify/verify-sdk-android/3.2.1)
+
+## 📧 Support
+
+For issues, questions, or contributions, please visit:
+- [GitHub Issues](https://github.com/ibm-verify/verify-sdk-android/issues)
+- [Contributing Guide](../../CONTRIBUTING.md)
+
+---
+
+**Release Date:** May 2026  
+**Version:** 3.2.1  
+**Previous Version:** 3.2.0

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/EnrollableSignatureTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/EnrollableSignatureTest.kt
@@ -386,6 +386,6 @@ class EnrollableSignatureTest {
         assert(result.contains("biometricAuthentication=true"))
         assert(result.contains("algorithmType=HmacSHA256"))
         assert(result.contains("authenticatorId=test-auth-id"))
-        assert(result.contains("enrollableType=FACE"))
+        assert(result.contains("enrollableType=face"))
     }
 }

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/EnrollableTypeTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/EnrollableTypeTest.kt
@@ -33,15 +33,6 @@ class EnrollableTypeTest {
     }
 
     @Test
-    fun fromString_withTOTP_shouldReturnTOTP() {
-        // When
-        val result = EnrollableType.fromString("TOTP")
-
-        // Then
-        assertEquals(EnrollableType.TOTP, result)
-    }
-
-    @Test
     fun fromString_withTOTPLowercase_shouldReturnTOTP() {
         // When
         val result = EnrollableType.fromString("totp")
@@ -51,21 +42,12 @@ class EnrollableTypeTest {
     }
 
     @Test
-    fun fromString_withTOTPMixedCase_shouldReturnTOTP() {
+    fun fromString_withTOTPUppercase_shouldReturnNull() {
         // When
-        val result = EnrollableType.fromString("ToTp")
+        val result = EnrollableType.fromString("TOTP")
 
         // Then
-        assertEquals(EnrollableType.TOTP, result)
-    }
-
-    @Test
-    fun fromString_withHOTP_shouldReturnHOTP() {
-        // When
-        val result = EnrollableType.fromString("HOTP")
-
-        // Then
-        assertEquals(EnrollableType.HOTP, result)
+        assertNull(result)
     }
 
     @Test
@@ -78,30 +60,12 @@ class EnrollableTypeTest {
     }
 
     @Test
-    fun fromString_withFACE_shouldReturnFACE() {
-        // When
-        val result = EnrollableType.fromString("FACE")
-
-        // Then
-        assertEquals(EnrollableType.FACE, result)
-    }
-
-    @Test
     fun fromString_withFACELowercase_shouldReturnFACE() {
         // When
         val result = EnrollableType.fromString("face")
 
         // Then
         assertEquals(EnrollableType.FACE, result)
-    }
-
-    @Test
-    fun fromString_withFINGERPRINT_shouldReturnFINGERPRINT() {
-        // When
-        val result = EnrollableType.fromString("FINGERPRINT")
-
-        // Then
-        assertEquals(EnrollableType.FINGERPRINT, result)
     }
 
     @Test
@@ -114,21 +78,21 @@ class EnrollableTypeTest {
     }
 
     @Test
-    fun fromString_withUSER_PRESENCE_shouldReturnUSER_PRESENCE() {
+    fun fromString_withUserPresenceCamelCase_shouldReturnUSER_PRESENCE() {
         // When
-        val result = EnrollableType.fromString("USER_PRESENCE")
+        val result = EnrollableType.fromString("userPresence")
 
         // Then
         assertEquals(EnrollableType.USER_PRESENCE, result)
     }
 
     @Test
-    fun fromString_withUSER_PRESENCELowercase_shouldReturnUSER_PRESENCE() {
+    fun fromString_withUserPresenceUppercase_shouldReturnNull() {
         // When
-        val result = EnrollableType.fromString("user_presence")
+        val result = EnrollableType.fromString("USER_PRESENCE")
 
         // Then
-        assertEquals(EnrollableType.USER_PRESENCE, result)
+        assertNull(result)
     }
 
     @Test
@@ -158,59 +122,6 @@ class EnrollableTypeTest {
         assertNull(result)
     }
 
-    @Test
-    fun forIsvaEnrollment_withTOTP_shouldReturnLowercase() {
-        // When
-        val result = EnrollableType.forIsvaEnrollment(EnrollableType.TOTP)
-
-        // Then
-        assertEquals("totp", result)
-    }
-
-    @Test
-    fun forIsvaEnrollment_withHOTP_shouldReturnLowercase() {
-        // When
-        val result = EnrollableType.forIsvaEnrollment(EnrollableType.HOTP)
-
-        // Then
-        assertEquals("hotp", result)
-    }
-
-    @Test
-    fun forIsvaEnrollment_withFACE_shouldReturnLowercase() {
-        // When
-        val result = EnrollableType.forIsvaEnrollment(EnrollableType.FACE)
-
-        // Then
-        assertEquals("face", result)
-    }
-
-    @Test
-    fun forIsvaEnrollment_withFINGERPRINT_shouldReturnLowercase() {
-        // When
-        val result = EnrollableType.forIsvaEnrollment(EnrollableType.FINGERPRINT)
-
-        // Then
-        assertEquals("fingerprint", result)
-    }
-
-    @Test
-    fun forIsvaEnrollment_withUSER_PRESENCE_shouldReturnUserPresence() {
-        // When
-        val result = EnrollableType.forIsvaEnrollment(EnrollableType.USER_PRESENCE)
-
-        // Then
-        assertEquals("userPresence", result)
-    }
-
-    @Test
-    fun forIsvaEnrollment_withNull_shouldReturnEmptyString() {
-        // When
-        val result = EnrollableType.forIsvaEnrollment(null)
-
-        // Then
-        assertEquals("", result)
-    }
 
     @Test
     fun name_shouldReturnEnumName() {
@@ -258,30 +169,31 @@ class EnrollableTypeTest {
     }
 
     @Test
-    fun toString_shouldReturnEnumName() {
-        // Then
-        assertEquals("TOTP", EnrollableType.TOTP.toString())
-        assertEquals("HOTP", EnrollableType.HOTP.toString())
-        assertEquals("FACE", EnrollableType.FACE.toString())
-        assertEquals("FINGERPRINT", EnrollableType.FINGERPRINT.toString())
-        assertEquals("USER_PRESENCE", EnrollableType.USER_PRESENCE.toString())
+    fun toString_shouldReturnCorrectFormat() {
+        // Then - matches v2 SubType.toString() format
+        assertEquals("totp", EnrollableType.TOTP.toString())
+        assertEquals("hotp", EnrollableType.HOTP.toString())
+        assertEquals("face", EnrollableType.FACE.toString())
+        assertEquals("fingerprint", EnrollableType.FINGERPRINT.toString())
+        assertEquals("userPresence", EnrollableType.USER_PRESENCE.toString())
     }
 
     @Test
-    fun fromString_roundTrip_shouldPreserveValue() {
+    fun fromString_toString_roundTrip_shouldPreserveValue() {
         // Given
         val types = EnrollableType.values()
 
-        // When/Then
+        // When/Then - toString() returns the format that fromString() expects
         for (type in types) {
-            val result = EnrollableType.fromString(type.name)
+            val stringValue = type.toString()
+            val result = EnrollableType.fromString(stringValue)
             assertEquals(type, result)
         }
     }
 
     @Test
-    fun forIsvaEnrollment_allTypes_shouldReturnValidStrings() {
-        // Given
+    fun toString_allTypes_shouldMatchV2Format() {
+        // Given - Expected format matches v2 SubType.toString()
         val expectedMappings = mapOf(
             EnrollableType.TOTP to "totp",
             EnrollableType.HOTP to "hotp",
@@ -292,7 +204,7 @@ class EnrollableTypeTest {
 
         // When/Then
         for ((type, expected) in expectedMappings) {
-            val result = EnrollableType.forIsvaEnrollment(type)
+            val result = type.toString()
             assertEquals(expected, result)
         }
     }

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/MFAAttributeInfoTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/MFAAttributeInfoTest.kt
@@ -221,7 +221,7 @@ class MFAAttributeInfoTest {
         assertTrue(attributes.containsKey("device_id"))
         assertTrue(attributes.containsKey("os_version"))
         assertTrue(attributes.containsKey("face_support"))
-        assertTrue(attributes.containsKey("device_insecure"))
+        assertTrue(attributes.containsKey("device_rooted"))
         assertTrue(attributes.containsKey("fingerprint_support"))
         assertTrue(attributes.containsKey("front_camera_support"))
         assertTrue(attributes.containsKey("verify_sdk_version"))
@@ -348,7 +348,7 @@ class MFAAttributeInfoTest {
         assertEquals(camelCase["deviceId"], snakeCase["device_id"])
         assertEquals(camelCase["osVersion"], snakeCase["os_version"])
         assertEquals(camelCase["faceSupport"], snakeCase["face_support"])
-        assertEquals(camelCase["deviceInsecure"], snakeCase["device_insecure"])
+        assertEquals(camelCase["deviceInsecure"], snakeCase["device_rooted"])   // different key
         assertEquals(camelCase["fingerprintSupport"], snakeCase["fingerprint_support"])
         assertEquals(camelCase["frontCameraSupport"], snakeCase["front_camera_support"])
         assertEquals(camelCase["verifySdkVersion"], snakeCase["verify_sdk_version"])

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/MFARegistrationExceptionTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/MFARegistrationExceptionTest.kt
@@ -86,7 +86,7 @@ class MFARegistrationExceptionTest {
         val exception = MFARegistrationException.NoEnrollableFactors(EnrollableType.USER_PRESENCE, cause)
 
         // Then
-        assertTrue(exception.message?.contains(EnrollableType.USER_PRESENCE.toString()) ?: false)
+        assertTrue(exception.message?.contains(EnrollableType.USER_PRESENCE.name) ?: false)
         assertEquals(cause, exception.cause)
     }
 

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProviderTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProviderTest.kt
@@ -1111,7 +1111,7 @@ class CloudRegistrationProviderTest {
                     "authenticatorId": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd",
                     "additionalData": [{
                         "name": "name",
-                        "value": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd.FINGERPRINT"
+                        "value": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd.fingerprint"
                     }],
                     "algorithm": "RSASHA256"
                 },
@@ -1245,7 +1245,7 @@ class CloudRegistrationProviderTest {
                     "authenticatorId": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd",
                     "additionalData": [{
                         "name": "name",
-                        "value": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd.FACE"
+                        "value": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd.face"
                     }],
                     "algorithm": "RSASHA256"
                 },
@@ -1379,7 +1379,7 @@ class CloudRegistrationProviderTest {
                     "authenticatorId": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd",
                     "additionalData": [{
                         "name": "name",
-                        "value": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd.USER_PRESENCE"
+                        "value": "5bbdcd60-92a0-4e0f-a14c-72cb1b8358cd.userPresence"
                     }],
                     "algorithm": "RSASHA256"
                 },

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorIntegrationTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorIntegrationTest.kt
@@ -80,7 +80,7 @@ class OnPremiseAuthenticatorIntegrationTest {
                             "urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Authenticator": {
                               "userPresenceMethods": [{
                                 "id": "uuid-test-factor-id-001",
-                                "keyHandle": "test-authenticator-id-001.USER_PRESENCE",
+                                "keyHandle": "test-authenticator-id-001.userPresence",
                                 "authenticator": "test-authenticator-id-001",
                                 "enabled": true,
                                 "algorithm": "SHA512withRSA"
@@ -137,7 +137,7 @@ class OnPremiseAuthenticatorIntegrationTest {
                             "urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Authenticator": {
                               "fingerprintMethods": [{
                                 "id": "uuid-test-factor-id-002",
-                                "keyHandle": "test-authenticator-id-001.FINGERPRINT",
+                                "keyHandle": "test-authenticator-id-001.fingerprint",
                                 "authenticator": "test-authenticator-id-001",
                                 "enabled": true,
                                 "algorithm": "SHA512withRSA"
@@ -348,7 +348,7 @@ class OnPremiseAuthenticatorIntegrationTest {
                           "location": "/mga/sps/apiauthsvc?StateId=test_state_token_001",
                           "type": "user_presence",
                           "serverChallenge": "test_server_challenge_001",
-                          "keyHandles": ["test-authenticator-id-001.USER_PRESENCE"]
+                          "keyHandles": ["test-authenticator-id-001.userPresence"]
                         }
                         """.trimIndent(),
                         status = HttpStatusCode.OK,

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/EnrollableType.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/EnrollableType.kt
@@ -11,19 +11,22 @@ enum class EnrollableType {
     FINGERPRINT,
     USER_PRESENCE;
 
+    override fun toString(): String {
+        return when (this) {
+            USER_PRESENCE -> "userPresence"
+            else -> name.lowercase()
+        }
+    }
+
     companion object {
         fun fromString(type: String): EnrollableType? {
-            return try {
-                valueOf(type.uppercase())
-            } catch (e: IllegalArgumentException) {
-                null
-            }
-        }
-
-        internal fun forIsvaEnrollment(type: EnrollableType?):String {
             return when (type) {
-                USER_PRESENCE -> "userPresence"
-                else -> type?.name?.lowercase() ?: ""
+                "fingerprint" -> FINGERPRINT
+                "face" -> FACE
+                "userPresence" -> USER_PRESENCE
+                "totp" -> TOTP
+                "hotp" -> HOTP
+                else -> null
             }
         }
     }

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/HashAlgorithmType.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/HashAlgorithmType.kt
@@ -11,7 +11,20 @@ import java.util.Locale
  * Values indicating the type of hash algorithm to use. Instantiates an instance of the conforming
  * type from a string representation.
  *
- * @param rawValue The name of the algorithm.
+ * The HashAlgorithmType enum represents the underlying hash algorithm (SHA-1, SHA-256, SHA-384,
+ * SHA-512) in an abstract way, independent of the cryptographic operation (HMAC vs RSA). This
+ * design allows the SDK to:
+ * - Store a single enum value that represents the hash algorithm
+ * - Convert to the appropriate format for different contexts (HMAC for TOTP, RSA for biometric)
+ * - Support both symmetric (HMAC) and asymmetric (RSA) operations with the same enum
+ *
+ * The enum accepts multiple string formats via [fromString] (e.g., "SHA256", "HmacSHA256",
+ * "RSASHA256", "SHA256withRSA") and provides conversion methods:
+ * - [toString] returns the HMAC format (e.g., "HmacSHA256")
+ * - [forSigning] returns the RSA signing format (e.g., "SHA256withRSA")
+ * - [toIsvFormat] returns the IBM Verify SaaS format (e.g., "RSASHA256")
+ *
+ * @param rawValue The default string representation of the algorithm (HMAC format).
  */
 @Serializable(with = HashAlgorithmTypeSerializer::class)
 enum class HashAlgorithmType(private val rawValue: String) {

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFAAttributeInfo.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/MFAAttributeInfo.kt
@@ -7,6 +7,8 @@ package com.ibm.security.verifysdk.mfa
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import android.provider.Settings
+import androidx.biometric.BiometricManager
 import androidx.core.content.edit
 import com.ibm.security.verifysdk.core.helper.ContextHelper
 import com.scottyab.rootbeer.RootBeer
@@ -80,22 +82,50 @@ object MFAAttributeInfo {
     private var lastRootCheck: Pair<Long, Boolean>? = null
 
     // Lazily computed static attributes (computed once and cached)
+    // Note: deviceId is NOT included here because it needs to be read fresh each time
+    // to support migration scenarios where the device ID is written after first access
     private val staticAttributes: Map<String, Any> by lazy {
         mapOf(
-            "deviceName" to Build.MODEL,
-            "deviceType" to Build.MANUFACTURER,
+            "deviceName" to deviceName,  // User-set device name from Settings
+            "deviceType" to Build.MODEL,  // Device model name (e.g., "Pixel 6")
             "platformType" to "Android",
             "osVersion" to Build.VERSION.RELEASE,
             "applicationId" to applicationBundleIdentifier,
             "applicationName" to applicationName,
             "applicationVersion" to applicationVersion,
-            "deviceId" to deviceID,
             "frontCameraSupport" to hasFrontCamera,
             "fingerprintSupport" to hasTouchID,
             "faceSupport" to hasFaceID,
             "verifySdkVersion" to BuildConfig.VERSION_NAME
         )
     }
+
+    /**
+     * Gets the device name as set by the user in device settings.
+     * Matches v2 SDK behavior for backward compatibility.
+     *
+     * For Android N_MR1 (API 25) and above, reads from Settings.Global.DEVICE_NAME.
+     * For older versions, reads from Settings.Secure "bluetooth_name".
+     * Falls back to Build.MODEL if no name is set.
+     */
+    private val deviceName: String
+        get() {
+            val name = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+                Settings.Global.getString(
+                    applicationContext.contentResolver,
+                    Settings.Global.DEVICE_NAME
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                Settings.Secure.getString(
+                    applicationContext.contentResolver,
+                    "bluetooth_name"
+                )
+            }
+            
+            // Fall back to Build.MODEL if device name is not set
+            return name?.takeIf { it.isNotEmpty() } ?: Build.MODEL
+        }
 
     /**
      * Checks if the device is rooted/insecure with caching.
@@ -142,10 +172,30 @@ object MFAAttributeInfo {
         get() = applicationContext.packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_FRONT)
 
     private val hasFaceID: Boolean
-        get() = applicationContext.packageManager.hasSystemFeature(PackageManager.FEATURE_FACE)
+        get() {
+            // Check if device has face recognition hardware
+            if (!applicationContext.packageManager.hasSystemFeature(PackageManager.FEATURE_FACE)) {
+                return false
+            }
+            
+            // Check if face biometrics are enrolled
+            val biometricManager = BiometricManager.from(applicationContext)
+            return biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK) ==
+                BiometricManager.BIOMETRIC_SUCCESS
+        }
 
     private val hasTouchID: Boolean
-        get() = applicationContext.packageManager.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT)
+        get() {
+            // Check if device has fingerprint hardware
+            if (!applicationContext.packageManager.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT)) {
+                return false
+            }
+            
+            // Check if fingerprints are enrolled
+            val biometricManager = BiometricManager.from(applicationContext)
+            return biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK) ==
+                BiometricManager.BIOMETRIC_SUCCESS
+        }
 
     private val applicationBundleIdentifier: String
         get() = applicationContext.packageName
@@ -212,9 +262,19 @@ object MFAAttributeInfo {
             staticAttributes
         }.toMutableMap()
         
-        // Add fresh deviceInsecure check (cached for 1 minute)
-        val insecureKey = if (snakeCaseKey) "device_insecure" else "deviceInsecure"
-        attributes[insecureKey] = deviceInsecure
+        // Add fresh deviceId (read from SharedPreferences each time to support migration)
+        val deviceIdKey = if (snakeCaseKey) "device_id" else "deviceId"
+        attributes[deviceIdKey] = deviceID
+        
+        // Add fresh root/insecure check (cached for 1 minute)
+        // Use different attribute names based on target platform:
+        // - snakeCaseKey = true  → IBM Verify Identity Access → "device_rooted"
+        // - snakeCaseKey = false → IBM Verify → "deviceInsecure"
+        if (snakeCaseKey) {
+            attributes["device_rooted"] = deviceInsecure
+        } else {
+            attributes["deviceInsecure"] = deviceInsecure
+        }
         
         return attributes
     }

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProvider.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProvider.kt
@@ -386,7 +386,7 @@ class CloudRegistrationProvider(data: String) :
             throw MFARegistrationException.InvalidAlgorithm(factor.algorithm)
         }
 
-        val keyName = "${metaData.id}.${type.name}"
+        val keyName = "${metaData.id}.${type}"
 
         // Generate the key pair with authenticationRequired = true.
         val publicKey = generateKeys(
@@ -476,7 +476,7 @@ class CloudRegistrationProvider(data: String) :
             throw MFARegistrationException.InvalidAlgorithm(factor.algorithm)
         }
 
-        val keyName = "${metaData.id}.${type.name}"
+        val keyName = "${metaData.id}.${type}"
         val isBiometric = type == EnrollableType.FACE || type == EnrollableType.FINGERPRINT
 
         // When authenticationRequired is true for a biometric key, the key is locked after

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt
@@ -256,7 +256,7 @@ class OnPremiseRegistrationProvider(data: String) :
             throw MFARegistrationException.InvalidAlgorithm(factor.algorithm)
         }
 
-        val keyName = "${authenticatorId}.${type.name}"
+        val keyName = "${authenticatorId}.${type}"
 
         // Generate the key pair with authenticationRequired = true.
         val publicKey = generateKeys(
@@ -344,7 +344,7 @@ class OnPremiseRegistrationProvider(data: String) :
             throw MFARegistrationException.InvalidAlgorithm(factor.algorithm)
         }
 
-        val keyName = "${authenticatorId}.${type.name}"
+        val keyName = "${authenticatorId}.${type}"
         val isBiometric = type == EnrollableType.FACE || type == EnrollableType.FINGERPRINT
 
         // OPT-1: When authenticationRequired is true for a biometric key, the key is locked after
@@ -391,9 +391,7 @@ class OnPremiseRegistrationProvider(data: String) :
             log.entering()
 
             val path =
-                "urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Authenticator:${
-                    EnrollableType.forIsvaEnrollment(type)
-                }Methods"
+                "urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Authenticator:${type}Methods"
             val enrollmentUrl = URL("${signatureEnrollableFactor.uri}?attributes=${path}")
 
             val requestBody = buildJsonObject {


### PR DESCRIPTION
## What does it do?
Merges `release/3.2.1` into `main`.

This release includes:
- restore v2-compatible signature key naming in MFA registration flows
- align device attribute handling for on-premise MFA flows
- normalize MFA enrollment algorithm and factor handling
- expand MFA test coverage for registration provider compatibility changes

## Motivtion and Context
This PR brings the 3.2.1 release line into `main` with targeted MFA compatibility and behavior fixes, plus the corresponding release documentation and versioning updates.

The branch primarily addresses interoperability and backward-compatibility concerns in MFA registration and on-premise flows, while also updating tests to reflect the intended serialization, attribute, and exception behavior. These changes ensure the release branch fixes are preserved in `main` and documented as part of the 3.2.1 release history.