### PR TITLE
Release 3.2.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,8 @@ plugins {
 }
 
 // used for release naming and in MFA SDK
-extra["versionName"] = "3.2.2"
-extra["versionCode"] = "120"
+extra["versionName"] = "3.2.3"
+extra["versionCode"] = "121"
 
 dependencies {
     add("implementation", enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.15.3"))

--- a/docs/releases/3.2.3.md
+++ b/docs/releases/3.2.3.md
@@ -1,0 +1,216 @@
+# IBM Verify SDK for Android - Release 3.2.3
+
+## Overview
+
+Version 3.2.3 is a patch release focused on token data preservation during registration finalization and QR code login support for on-premise authenticators. This release ensures critical token metadata is retained throughout the registration lifecycle and extends passwordless login capabilities to on-premise deployments.
+
+## 🚨 Breaking Changes
+
+None.
+
+## ✨ New Features
+
+### 1. QR Code Passwordless Login for On-Premise Authenticators
+
+**New:** [`OnPremiseAuthenticatorService.login()`](../../sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorService.kt:324) method for QR code-based authentication flows.
+
+#### Overview
+
+Extends QR code passwordless login support (introduced in 3.2.2 for cloud) to on-premise IBM Verify Identity Access deployments. Users can scan a QR code and approve login from their mobile device without entering passwords.
+
+#### Usage Example
+
+```kotlin
+val service = OnPremiseAuthenticatorService(
+    _accessToken = authenticator.token.accessToken,
+    _refreshUri = authenticator.refreshUri,
+    _transactionUri = authenticator.transactionUri,
+    _authenticatorId = authenticator.id,
+    _clientId = authenticator.clientId,
+    _ignoreSslCertificate = authenticator.ignoreSSLCertificate,
+    httpClient = NetworkHelper.getInstance
+)
+
+// After scanning QR code and extracting the login session identifier
+service.login(
+    qrLoginEndpoint = "https://onprem.company.com/mga/sps/mmfa/user/mgmt/login",
+    code = "abc123xyz"  // The lsi from QR code
+).onSuccess {
+    println("Login successful")
+}.onFailure { error ->
+    println("Login failed: ${error.message}")
+}
+```
+
+#### Method Signature
+
+```kotlin
+suspend fun login(
+    qrLoginEndpoint: String,
+    code: String
+): Result<Unit>
+```
+
+#### Parameters
+
+- **`qrLoginEndpoint`**: The full URL of the on-premise login endpoint
+- **`code`**: The login session identifier (lsi) extracted from the QR code
+
+#### Returns
+
+- **Success:** `Unit` indicating the login was approved
+- **Failure:** Exception indicating why the login failed
+  - `AuthorizationException` for 401 authentication failures
+  - `MFAServiceException.General` for other errors
+
+#### Implementation Details
+
+- Creates JSON payload: `{"code": "<lsi_value>"}`
+- Makes POST request with bearer token authentication
+- Handles error responses with structured exception types
+- Aligns with cloud authenticator login implementation from 3.2.2
+
+## 🐛 Bug Fixes
+
+### 1. Token Additional Data Preservation During Registration
+
+**Fixed:** Token metadata loss during registration finalization in both cloud and on-premise flows.
+
+#### Problem
+
+During the `finalize()` step of registration, the token refresh operation would overwrite the original token's `additionalData` map, losing important fields like:
+- `display_name` - User's display name from initial token response
+- `authenticator_id` - Authenticator identifier
+- `ISV_push_enabled` - Push notification capability flag
+- Other custom fields from initial authorization
+
+#### Solution
+
+Modified both [`CloudRegistrationProvider.finalize()`](../../sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProvider.kt:604) and [`OnPremiseRegistrationProvider.finalize()`](../../sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt:481) to:
+
+1. Save original `additionalData` before token refresh
+2. Merge original data with refreshed token data
+3. Preserve all fields from initial token response
+
+```kotlin
+// Save original additional data
+val originalAdditionalData = tokenInfo.additionalData
+
+// Refresh token
+val refreshedToken: TokenInfo = decoder.decodeFromString(responseBodyData)
+
+// Merge: preserve original fields, allow refresh response to override
+tokenInfo = refreshedToken.copy(
+    additionalData = originalAdditionalData + refreshedToken.additionalData
+)
+```
+
+#### Impact
+
+- `display_name` and other metadata now correctly available in finalized authenticator
+- Applications can reliably access token additional data after registration
+- Fixes potential issues where apps depend on initial token metadata
+
+## 🧪 Testing
+
+### New Test Coverage
+
+Added comprehensive test suite for on-premise registration edge cases in [`OnPremiseRegistrationProviderTest`](../../sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProviderTest.kt):
+
+1. **`testEnrollNoServiceName_Success()`** - Tests enrollment when `service_name` is missing from metadata
+   - Verifies serviceName defaults to host from `details_url`
+   - Confirms authenticator creation with no enrolled factors
+   - Validates complete registration flow with minimal metadata
+
+2. **`testEnrollNoAccountName_Success()`** - Tests enrollment with empty accountName parameter
+   - Verifies accountName remains empty as passed to `initiate()`
+   - Confirms `display_name` is stored in `token.additionalData`
+   - Validates registration succeeds with empty account name
+
+Both tests converted from Swift SDK test suite to ensure cross-platform parity.
+
+All existing tests continue to pass.
+
+## 📚 Documentation
+
+### New Documentation Files
+- `docs/releases/3.2.3.md` - This release document
+
+### Updated Documentation
+- Added comprehensive KDoc documentation for `OnPremiseAuthenticatorService.login()` method
+- Includes usage examples, parameter descriptions, and implementation details
+
+## 🔄 Upgrade Notes
+
+Update your dependency declarations to 3.2.3:
+
+```kotlin
+dependencies {
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-authentication:3.2.3")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-mfa:3.2.3")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-core:3.2.3")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-fido2:3.2.3")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-adaptive:3.2.3")
+}
+```
+
+### Migration from 3.2.2
+
+No breaking changes. This is a backward-compatible release with bug fixes and new features.
+
+#### Token Additional Data (Automatic Fix)
+
+If your application accesses `authenticator.token.additionalData` after registration, you will now correctly receive all fields from the initial token response. No code changes required.
+
+#### Using QR Code Login for On-Premise (New Feature)
+
+If you want to implement QR code-based passwordless login for on-premise authenticators:
+
+1. **Scan QR Code**: Use your QR code scanning implementation to extract the login session identifier (lsi)
+2. **Call Login Method**: Use the new `login()` method on `OnPremiseAuthenticatorService`
+3. **Handle Response**: Process success/failure results appropriately
+
+```kotlin
+// Example integration
+val loginCode = extractCodeFromQrScan(qrCodeData)
+val endpoint = extractEndpointFromQrScan(qrCodeData)
+
+service.login(
+    qrLoginEndpoint = endpoint,
+    code = loginCode
+).onSuccess {
+    // Navigate to success screen
+}.onFailure { error ->
+    // Show error message to user
+}
+```
+
+## 🐛 Known Issues
+
+None at this time.
+
+## 📝 Additional Notes
+
+- Token preservation fix ensures metadata consistency throughout registration lifecycle
+- QR code login now available for both cloud (3.2.2) and on-premise (3.2.3) authenticators
+- Test coverage improvements ensure cross-platform SDK parity
+- All changes are backward compatible
+- Recommended upgrade for applications using MFA registration or QR code login
+
+## 🔗 Links
+
+- [GitHub Release](https://github.com/ibm-verify/verify-sdk-android/releases/tag/3.2.3)
+- [Repository](https://github.com/ibm-verify/verify-sdk-android)
+- [JitPack](https://jitpack.io/#ibm-verify/verify-sdk-android/3.2.3)
+
+## 📧 Support
+
+For issues, questions, or contributions, please visit:
+- [GitHub Issues](https://github.com/ibm-verify/verify-sdk-android/issues)
+- [Contributing Guide](../../CONTRIBUTING.md)
+
+---
+
+**Release Date:** May 2026  
+**Version:** 3.2.3  
+**Previous Version:** 3.2.2

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProviderTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProviderTest.kt
@@ -800,4 +800,244 @@ class OnPremiseRegistrationProviderTest {
 
         httpClient.close()
     }
+
+    /**
+     * Test enrollment without service name in metadata.
+     *
+     * When service_name is not provided in metadata, the serviceName should default
+     * to the host from the details_url.
+     */
+    @Test
+    fun testEnrollNoServiceName_Success() = runTest {
+        val qrCodeJson = """
+        {
+            "code": "test_authorization_code_002",
+            "details_url": "https://test.example.com/mga/sps/mmfa/user/mgmt/details",
+            "client_id": "AuthenticatorClient",
+            "ignoreSSLCertificate": false
+        }
+        """.trimIndent()
+
+        val mockEngine = MockEngine { request ->
+            when {
+                // Details endpoint without service_name in metadata
+                request.url.encodedPath.contains("/details") -> {
+                    respond(
+                        content = """
+                        {
+                          "authntrxn_endpoint": "https://test.example.com/scim/Me",
+                          "metadata": {},
+                          "discovery_mechanisms": [
+                            "urn:ibm:security:authentication:asf:mechanism:mobile_user_approval:user_presence"
+                          ],
+                          "enrollment_endpoint": "https://test.example.com/scim/Me",
+                          "qrlogin_endpoint": "https://test.example.com/mga/sps/apiauthsvc/policy/qrcode_response",
+                          "hotp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/hotp",
+                          "totp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/totp",
+                          "version": "11.0.1.0",
+                          "token_endpoint": "https://test.example.com/mga/sps/oauth/oauth20/token"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                // Token endpoint
+                request.url.encodedPath.contains("/oauth20/token") -> {
+                    respond(
+                        content = """
+                        {
+                          "access_token": "A1b2C3D4",
+                          "refresh_token": "test_refresh_token_002",
+                          "scope": "mmfaAuthn",
+                          "authenticator_id": "test-authenticator-id-002",
+                          "ISV_push_enabled": "true",
+                          "token_type": "bearer",
+                          "display_name": "testuser@example.com",
+                          "expires_in": 3599
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json;charset=UTF-8")
+                    )
+                }
+                // Enrollment endpoint
+                request.url.encodedPath.contains("/scim/Me") -> {
+                    respond(
+                        content = """
+                        {
+                          "id": "test-authenticator-id-002",
+                          "schemas": ["urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Authenticator"],
+                          "urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Authenticator": {
+                            "enabled": true
+                          }
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = true
+                })
+            }
+        }
+
+        val provider = OnPremiseRegistrationProvider(qrCodeJson)
+        
+        // Initiate with account name
+        val initResult = provider.initiate(
+            accountName = "OnPremise account",
+            pushToken = "abc123",
+            additionalHeaders = null,
+            httpClient = httpClient
+        )
+
+        assertTrue("Initiate should succeed", initResult.isSuccess)
+        assertNotNull("Provider should not be null", provider)
+
+        // Finalize enrollment
+        val finalizeResult = provider.finalize(httpClient)
+
+        assertTrue("Finalize should succeed", finalizeResult.isSuccess)
+        finalizeResult.onSuccess { authenticator ->
+            assertNotNull("Authenticator should not be null", authenticator)
+            assertEquals("A1b2C3D4", authenticator.token.accessToken)
+            // Service name should default to host when not provided in metadata
+            assertEquals("test.example.com", authenticator.serviceName)
+            // No factors enrolled yet
+            assertFalse("User presence should not be enrolled", authenticator.userPresence != null)
+            assertFalse("Biometric should not be enrolled", authenticator.biometric != null)
+        }
+
+        httpClient.close()
+    }
+
+    /**
+     * Test enrollment without account name provided.
+     *
+     * When accountName is empty string, it remains empty in the authenticator.
+     * The display_name from token response is stored in additionalData but not
+     * automatically assigned to accountName.
+     */
+    @Test
+    fun testEnrollNoAccountName_Success() = runTest {
+        val qrCodeJson = """
+        {
+            "code": "test_authorization_code_003",
+            "details_url": "https://test.example.com/mga/sps/mmfa/user/mgmt/details",
+            "client_id": "AuthenticatorClient",
+            "ignoreSSLCertificate": false
+        }
+        """.trimIndent()
+
+        val mockEngine = MockEngine { request ->
+            when {
+                // Details endpoint
+                request.url.encodedPath.contains("/details") -> {
+                    respond(
+                        content = """
+                        {
+                          "authntrxn_endpoint": "https://test.example.com/scim/Me",
+                          "metadata": {"service_name": "Test Service"},
+                          "discovery_mechanisms": [
+                            "urn:ibm:security:authentication:asf:mechanism:mobile_user_approval:user_presence"
+                          ],
+                          "enrollment_endpoint": "https://test.example.com/scim/Me",
+                          "qrlogin_endpoint": "https://test.example.com/mga/sps/apiauthsvc/policy/qrcode_response",
+                          "hotp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/hotp",
+                          "totp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/totp",
+                          "version": "11.0.1.0",
+                          "token_endpoint": "https://test.example.com/mga/sps/oauth/oauth20/token"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                // Token endpoint
+                request.url.encodedPath.contains("/oauth20/token") -> {
+                    respond(
+                        content = """
+                        {
+                          "access_token": "A1b2C3D4",
+                          "refresh_token": "test_refresh_token_003",
+                          "scope": "mmfaAuthn",
+                          "authenticator_id": "test-authenticator-id-003",
+                          "ISV_push_enabled": "true",
+                          "token_type": "bearer",
+                          "display_name": "testuser",
+                          "expires_in": 3599
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json;charset=UTF-8")
+                    )
+                }
+                // Enrollment endpoint
+                request.url.encodedPath.contains("/scim/Me") -> {
+                    respond(
+                        content = """
+                        {
+                          "id": "test-authenticator-id-003",
+                          "schemas": ["urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Authenticator"],
+                          "urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Authenticator": {
+                            "enabled": true
+                          }
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = true
+                })
+            }
+        }
+
+        val provider = OnPremiseRegistrationProvider(qrCodeJson)
+        
+        // Initiate with empty account name
+        val initResult = provider.initiate(
+            accountName = "",
+            pushToken = "abc123",
+            additionalHeaders = null,
+            httpClient = httpClient
+        )
+
+        assertTrue("Initiate should succeed", initResult.isSuccess)
+        assertNotNull("Provider should not be null", provider)
+
+        // Finalize enrollment
+        val finalizeResult = provider.finalize(httpClient)
+
+        assertTrue("Finalize should succeed", finalizeResult.isSuccess)
+        finalizeResult.onSuccess { authenticator ->
+            assertNotNull("Authenticator should not be null", authenticator)
+            assertEquals("A1b2C3D4", authenticator.token.accessToken)
+            // Account name remains empty as passed to initiate()
+            assertEquals("", authenticator.accountName)
+            // display_name is available in token additionalData
+            assertEquals("testuser", authenticator.token.additionalData["display_name"])
+            // No biometric enrolled yet
+            assertFalse("Biometric should not be enrolled", authenticator.biometric != null)
+        }
+
+        httpClient.close()
+    }
 }

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProvider.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProvider.kt
@@ -601,6 +601,10 @@ class CloudRegistrationProvider(data: String) :
 
         return try {
 
+            // Save original additional data from initial token response
+            // This preserves fields like display_name, authenticator_id, ISV_push_enabled, etc.
+            val originalAdditionalData = tokenInfo.additionalData
+
             val registrationUrl =
                 URL("${initializationInfo.uri}?metadataInResponse=false")
 
@@ -618,7 +622,11 @@ class CloudRegistrationProvider(data: String) :
 
             if (response.status.isSuccess()) {
                 response.bodyAsText().let { responseBodyData ->
-                    tokenInfo = decoder.decodeFromString(responseBodyData)
+                    val refreshedToken: TokenInfo = decoder.decodeFromString(responseBodyData)
+                    // Merge additional data: preserve original fields, allow refresh response to override
+                    tokenInfo = refreshedToken.copy(
+                        additionalData = originalAdditionalData + refreshedToken.additionalData
+                    )
                 }
                 Result.success(
                     CloudAuthenticator(

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorService.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorService.kt
@@ -9,6 +9,8 @@ import com.ibm.security.verifysdk.authentication.api.OAuthProvider
 import com.ibm.security.verifysdk.authentication.model.TokenInfo
 import com.ibm.security.verifysdk.core.extension.entering
 import com.ibm.security.verifysdk.core.extension.exiting
+import com.ibm.security.verifysdk.core.extension.logError
+import com.ibm.security.verifysdk.core.extension.logInfo
 import com.ibm.security.verifysdk.core.helper.ContextHelper
 import com.ibm.security.verifysdk.core.helper.NetworkHelper
 import com.ibm.security.verifysdk.mfa.MFAAttributeInfo
@@ -35,6 +37,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.content.TextContent
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
@@ -135,6 +138,10 @@ class OnPremiseAuthenticatorService(
 
     val ignoreSslCertificate: Boolean
         get() = _ignoreSslCertificate
+
+    companion object {
+        private const val TAG = "OnPremAuthService"
+    }
 
     /**
      * Refreshes the OAuth token with **CRITICAL** persistence guarantees.
@@ -314,6 +321,101 @@ class OnPremiseAuthenticatorService(
             )
         }
     }
+    /**
+     * Performs QR code login for OnPremise authenticators.
+     *
+     * This function sends a login request to the OnPremise server using the provided
+     * QR login endpoint and login session identifier (lsi). The request is authenticated
+     * using the authenticator's OAuth access token.
+     *
+     * ## Usage Example
+     * ```kotlin
+     * val service = OnPremiseAuthenticatorService(...)
+     * val result = service.login(
+     *     qrLoginEndpoint = "https://onprem.company.com/mga/sps/mmfa/user/mgmt/login",
+     *     code = "abc123xyz"  // The lsi from QR code
+     * )
+     *
+     * result.onSuccess {
+     *     // Login successful
+     * }.onFailure { error ->
+     *     // Handle error
+     * }
+     * ```
+     *
+     * @param qrLoginEndpoint The full URL of the OnPremise login endpoint
+     * @param code The login session identifier (lsi) from the QR code
+     *
+     * @return A [Result] containing either:
+     *         - Success: Unit indicating the login was successful
+     *         - Failure: An exception indicating why the login failed
+     *
+     * @throws kotlinx.coroutines.CancellationException if the coroutine is cancelled
+     * @throws MFAServiceException.General if the request fails
+     *
+     * @see com.ibm.security.verifysdk.mfa.model.onprem.OnPremiseAuthenticator
+     */
+    suspend fun login(
+        qrLoginEndpoint: String,
+        code: String
+    ): Result<Unit> {
+        return try {
+            log.entering()
+            logInfo(TAG) { "Starting QR code login for authenticator $authenticatorId" }
+            
+            // Build JSON payload with the lsi code (same as v2 implementation)
+            val jsonBody = buildJsonObject {
+                put("lsi", JsonPrimitive(code))
+            }
+            
+            // Make POST request to login endpoint
+            val response = httpClient.post {
+                url(qrLoginEndpoint)
+                bearerAuth(accessToken)
+                contentType(ContentType.Application.Json)
+                accept(ContentType.Application.Json)
+                setBody(TextContent(jsonBody.toString(), ContentType.Application.Json))
+            }
+            
+            // Handle response
+            if (response.status.isSuccess()) {
+                logInfo(TAG) { "QR code login successful for authenticator $authenticatorId" }
+                Result.success(Unit)
+            } else {
+                val errorBody = response.bodyAsText()
+                logError(TAG) { "QR code login failed for authenticator $authenticatorId: ${response.status} - $errorBody" }
+                
+                // Parse error response if available
+                val errorMessage = try {
+                    val json = Json { ignoreUnknownKeys = true }
+                    val errorResponse = json.parseToJsonElement(errorBody).jsonObject
+                    errorResponse["error_description"]?.toString()?.trim('"')
+                        ?: errorResponse["error"]?.toString()?.trim('"')
+                        ?: "Login failed with status ${response.status.value}"
+                } catch (e: Exception) {
+                    "Login failed with status ${response.status.value}"
+                }
+                
+                Result.failure(
+                    MFAServiceException.General(errorMessage)
+                )
+            }
+        } catch (e: CancellationException) {
+            // Don't wrap cancellation exceptions
+            throw e
+        } catch (e: Exception) {
+            logError(TAG, e) { "Exception during QR code login for authenticator $authenticatorId" }
+            Result.failure(
+                MFAServiceException.General(
+                    "Exception during login: ${e.message}",
+                    e
+                )
+            )
+        } finally {
+            log.exiting()
+        }
+    }
+
 
     suspend fun remove(httpClient: HttpClient = NetworkHelper.getInstance): Result<Unit> {
 
@@ -371,14 +473,26 @@ class OnPremiseAuthenticatorService(
 
         // Get all transaction IDs for this authenticator
         val transactionIds = if (transactionId != null) {
-            // If specific transaction requested, only get that one
-            listOf(transactionId)
+            // If specific transaction requested, validate it belongs to this authenticator first
+            val belongsToThisAuthenticator = transactionResult.attributes.any {
+                it.transactionId == transactionId &&
+                it.uri == "mmfa:request:authenticator:id" &&
+                it.values.contains(authenticatorId)
+            }
+            if (belongsToThisAuthenticator) {
+                listOf(transactionId)
+            } else {
+                log.debug("Transaction $transactionId does not belong to authenticator $authenticatorId")
+                emptyList()
+            }
         } else if (identifiers.isNotEmpty()) {
             // Get all transactions for this authenticator
             identifiers.map { it.transactionId }
         } else {
-            // Fallback to all transactions
-            transactionResult.transactions.map { it.transactionId }
+            // No transactions for this authenticator - return empty list
+            // This prevents attempting to process transactions that belong to other authenticators
+            log.debug("No transactions found for authenticator $authenticatorId")
+            emptyList()
         }
 
         val now = Clock.System.now()
@@ -420,6 +534,24 @@ class OnPremiseAuthenticatorService(
             if (response.status.isSuccess()) {
                 val verificationInfo =
                     decoder.decodeFromString<VerificationInfo>(response.bodyAsText())
+
+                // Validate that this transaction belongs to this authenticator
+                // This prevents one authenticator from attempting to complete another's transaction
+                val authenticatorIdAttribute = transactionResult.attributes.firstOrNull {
+                    it.transactionId == transactionInfoResult.transactionId &&
+                    it.uri == "mmfa:request:authenticator:id"
+                }
+
+                if (authenticatorIdAttribute != null) {
+                    if (!authenticatorIdAttribute.values.contains(authenticatorId)) {
+                        log.debug("Transaction $transactionId does not belong to authenticator $authenticatorId")
+                        return Result.failure(
+                            MFAServiceException.General(
+                                "Transaction $transactionId does not belong to authenticator $authenticatorId"
+                            )
+                        )
+                    }
+                }
 
                 // Extract expiry time from attributesPending array
                 // Look for mmfa.transactionPending.minAgeBeforeAbort attribute

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt
@@ -478,6 +478,10 @@ class OnPremiseRegistrationProvider(data: String) :
         return try {
             log.entering()
 
+            // Save original additional data from initial token response
+            // This preserves fields like display_name, authenticator_id, ISV_push_enabled, etc.
+            val originalAdditionalData = tokenInfo.additionalData
+
             // Generate requestBody for token refresh based on OnPremiseAuthenticatorService.refreshToken
             val attributes = MFAAttributeInfo.dictionary(snakeCaseKey = true).toMutableMap()
             attributes["accountName"] = accountName
@@ -503,7 +507,11 @@ class OnPremiseRegistrationProvider(data: String) :
 
             if (response.status.isSuccess()) {
                 response.bodyAsText().let { responseBodyData ->
-                    tokenInfo = decoder.decodeFromString(responseBodyData)
+                    val refreshedToken: TokenInfo = decoder.decodeFromString(responseBodyData)
+                    // Merge additional data: preserve original fields, allow refresh response to override
+                    tokenInfo = refreshedToken.copy(
+                        additionalData = originalAdditionalData + refreshedToken.additionalData
+                    )
                 }
                 Result.success(
                     OnPremiseAuthenticator(


### PR DESCRIPTION
## What does it do

- Adds QR login support for on-premise authenticators (`OnPremiseAuthenticatorService.login()`)
- Fixes token metadata loss during registration finalization (preserves `display_name`, `authenticator_id`, etc.)
- Adds two on-premise registration edge case tests from Swift SDK


## Motivation and Context

### QR Login
Extends passwordless QR login (added for cloud in 3.2.2) to on-premise IBM Verify Identity Access deployments for feature parity.

### additionalData Preservation
Token refresh during `finalize()` was overwriting `additionalData`, losing critical metadata from initial authorization. Fix merges original data with refreshed token.
