### PR TITLE
Release 3.2.4

### DIFF
--- a/sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt
+++ b/sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt
@@ -354,11 +354,6 @@ object NetworkHelper {
     }
 
     fun insecureTrustManager(): X509TrustManager {
-
-        if (!BuildConfig.DEBUG) {
-            throw IllegalStateException("Insecure Trust Manager should not be used in production!")
-        }
-
         return object : X509TrustManager {
             override fun checkClientTrusted(
                 chain: Array<out java.security.cert.X509Certificate>?,


### PR DESCRIPTION
## What does it do

This PR removes the `BuildConfig.DEBUG` check from the `NetworkHelper.insecureTrustManager()` method, allowing SSL certificate bypass to work in production/release builds when `NetworkHelper.allowInsecureSSL` is explicitly set to `true`.

**Changes:**
- Removed the build-type restriction that threw `IllegalStateException("Insecure Trust Manager should not be used in production!")` in release builds
- The `allowInsecureSSL` flag now functions consistently across both debug and release build variants
- Applications can now use self-signed certificates with OnPremise IBM Verify Access servers in production environments

## Motivation and Context

**Problem:**
Users encountered a registration failure with the error message "Insecure Trustmanager should not be used in production" even after explicitly setting `NetworkHelper.allowInsecureSSL = true` in their application. This occurred because the SDK had two conflicting security checks:

1. The `allowInsecureSSL` flag (app-level permission) - which users set to `true`
2. A hidden `BuildConfig.DEBUG` check (build-type restriction) - which blocked the functionality in release builds

This created an inconsistent and confusing developer experience where the documented API (`allowInsecureSSL`) didn't work as expected in production builds.

**Solution:**
The `allowInsecureSSL` flag should be the single source of truth for controlling SSL bypass functionality. By removing the build-type check, we:

- Restore consistency between the API contract and actual behavior
- Allow legitimate use cases (OnPremise servers with self-signed certificates) to work in production
- Maintain security through the existing two-level security model:
  - App-level: `NetworkHelper.allowInsecureSSL` must be explicitly enabled (defaults to `false`)
  - Authenticator-level: Only authenticators with `ignoreSSLCertificate=true` will bypass SSL

**Security Considerations:**
- The change maintains secure defaults (`allowInsecureSSL = false`)
- Applications must make an explicit, conscious decision to enable SSL bypass
- The functionality only affects authenticators specifically configured to ignore SSL certificates
- This aligns with the documented behavior and developer expectations

**Affected Components:**
- `NetworkHelper.insecureTrustManager()`
- `NetworkHelper.createInsecureClient()`
- `OAuthProvider.ignoreSsl` property
- OnPremise authenticator registration and service operations