### PR TITLE
Release 3.2.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,8 @@ plugins {
 }
 
 // used for release naming and in MFA SDK
-extra["versionName"] = "3.2.5"
-extra["versionCode"] = "123"
+extra["versionName"] = "3.2.6"
+extra["versionCode"] = "124"
 
 dependencies {
     add("implementation", enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.15.3"))

--- a/docs/releases/3.2.6.md
+++ b/docs/releases/3.2.6.md
@@ -1,0 +1,284 @@
+# IBM Verify SDK for Android - Release 3.2.6
+
+## Overview
+
+Version 3.2.6 is a feature release that introduces custom User-Agent support for HTTP requests, improves handling of malformed JSON data from legacy servers, and enhances TOTP URI parameter management. This release also significantly expands test coverage across core networking and MFA registration flows.
+
+The key improvements center around:
+- Custom User-Agent header support for application identification
+- Robust JSON parsing for legacy server responses with single-quoted strings
+- Intelligent TOTP URI parameter handling to prevent duplication
+- Comprehensive test coverage for new and existing functionality
+
+## Breaking Changes
+
+None.
+
+This is a backward-compatible feature release. All existing code using 3.2.5 will continue to work without modification.
+
+## New Features
+
+### 1. Custom User-Agent Support
+
+**New:** [`NetworkHelper.customUserAgent`](../../sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt:197) property for setting custom User-Agent headers
+
+#### Overview
+
+Applications can now set a custom User-Agent header that will be included in all HTTP requests made by the SDK. This enables better application identification in server logs, analytics, and debugging scenarios.
+
+#### Usage Example
+
+```kotlin
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        // Set custom User-Agent for all SDK requests
+        NetworkHelper.customUserAgent = "MyApp/1.0.0 (Android ${Build.VERSION.RELEASE})"
+    }
+}
+```
+
+#### Implementation Details
+
+**Property Declaration:**
+```kotlin
+var customUserAgent: String? = null
+    set(value) {
+        if (field != value) {
+            field = value
+            invalidateClient()
+        }
+    }
+```
+
+**Interceptor Integration:**
+```kotlin
+private fun createUserAgentInterceptor(): Interceptor? {
+    return customUserAgent?.let { userAgent ->
+        Interceptor { chain ->
+            val request = chain.request().newBuilder()
+                .header("User-Agent", userAgent)
+                .build()
+            chain.proceed(request)
+        }
+    }
+}
+```
+
+The User-Agent interceptor is automatically integrated into both secure and insecure HTTP clients through the shared helper method, ensuring consistent behavior across all SDK network operations.
+
+#### Benefits
+
+- **Application Identification**: Easily identify your app in server logs and analytics
+- **Version Tracking**: Include app version and platform information for debugging
+- **Compliance**: Meet organizational requirements for User-Agent reporting
+- **Automatic Invalidation**: Changing the User-Agent automatically recreates the HTTP client
+- **Consistent Application**: Works with both secure and insecure SSL clients
+
+## Bug Fixes
+
+### 1. Malformed JSON Handling in Transaction Attributes
+
+**Fixed:** [`OnPremiseAuthenticatorService.createPendingTransactions()`](../../sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorService.kt:812) now handles legacy JSON with single quotes
+
+#### Problem
+
+Some on-premise IBM Verify Access deployments return transaction attributes with JSON strings using single quotes instead of double quotes, which violates the JSON specification and causes parsing failures:
+
+```json
+{'denyReasonEnabled':'true'}  // Invalid JSON
+```
+
+#### Solution
+
+Added automatic normalization of single quotes to double quotes before JSON parsing:
+
+```kotlin
+// Handle malformed JSON with single quotes by replacing them with double quotes
+// This is a workaround for servers that send invalid JSON format
+val normalizedJsonString = jsonString.replace('\'', '"')
+val jsonElement = Json.parseToJsonElement(normalizedJsonString).jsonObject
+```
+
+#### Impact
+
+- Improved compatibility with legacy on-premise deployments
+- Graceful handling of non-standard JSON responses
+- No impact on correctly formatted JSON (double quotes remain unchanged)
+- Enables transaction attribute parsing in environments with older server versions
+
+### 2. TOTP URI Parameter Duplication Prevention
+
+**Fixed:** [`OnPremiseRegistrationProvider.enrollOneTimePasscode()`](../../sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt:465) now prevents duplicate query parameters in TOTP URIs
+
+#### Problem
+
+When constructing TOTP URIs from server responses, the SDK would blindly append `digits`, `period`, and `algorithm` parameters even if they already existed in the base URI, resulting in malformed URIs:
+
+```
+otpauth://totp/Service:user?secret=ABC&digits=6&digits=8&period=30&period=30
+```
+
+#### Solution
+
+Added intelligent parameter checking before appending:
+
+```kotlin
+// Parse the base URI to check for existing parameters
+val uri = baseUri.toUri()
+val existingDigits = uri.getQueryParameter("digits")
+val existingPeriod = uri.getQueryParameter("period")
+val existingAlgorithm = uri.getQueryParameter("algorithm")
+
+// Build URI with parameters, only adding if they don't already exist
+val completeUri = buildString {
+    append(baseUri)
+    
+    // Add separator if needed
+    if (!baseUri.contains("?")) {
+        append("?")
+    } else if (!baseUri.endsWith("&") && !baseUri.endsWith("?")) {
+        append("&")
+    }
+    
+    val params = mutableListOf<String>()
+    
+    // Only add parameters if they don't already exist in the URI
+    if (existingDigits == null) {
+        params.add("digits=$digits")
+    }
+    if (existingPeriod == null) {
+        params.add("period=$period")
+    }
+    if (existingAlgorithm == null) {
+        params.add("algorithm=$algorithmParam")
+    }
+    
+    append(params.joinToString("&"))
+}.trimEnd('?', '&')  // Clean up trailing separators if no params were added
+```
+
+#### Impact
+
+- Prevents malformed TOTP URIs with duplicate parameters
+- Respects server-provided parameter values when present
+- Ensures OTP authenticators are created with correct configuration
+- Improves compatibility with various server implementations
+
+## Improvements
+
+### 1. Enhanced HTTP Client Architecture
+
+**Enhanced:** HTTP client creation in [`NetworkHelper`](../../sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt)
+
+#### Changes
+
+- Centralized User-Agent interceptor creation through [`createUserAgentInterceptor()`](../../sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt:436)
+- Consistent interceptor integration in both [`createOkHttpClient()`](../../sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt:414) and [`createInsecureClient()`](../../sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt:549)
+- Automatic client invalidation when User-Agent changes
+- Thread-safe property access with proper synchronization
+
+#### Benefits
+
+- Maintainable code with shared interceptor logic
+- Guaranteed consistency across all HTTP clients
+- Efficient client recreation only when necessary
+- Clear separation of concerns
+
+### 2. Comprehensive Documentation
+
+**Enhanced:** KDoc documentation throughout [`NetworkHelper`](../../sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt)
+
+#### Additions
+
+- Detailed [`customUserAgent`](../../sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt:197) property documentation with:
+  - Use cases and examples
+  - Format recommendations
+  - Thread safety notes
+  - Advanced usage patterns
+- Enhanced [`createUserAgentInterceptor()`](../../sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt:436) method documentation
+- Cross-references to related functionality
+
+
+## Upgrade Notes
+
+Update your dependency declarations to 3.2.6:
+
+```kotlin
+dependencies {
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-authentication:3.2.6")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-mfa:3.2.6")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-core:3.2.6")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-fido2:3.2.6")
+    implementation("com.github.ibm-verify.verify-sdk-android:verify-sdk-adaptive:3.2.6")
+}
+```
+
+### Migration Notes
+
+No code changes are required when upgrading from 3.2.5 to 3.2.6. All changes are backward-compatible.
+
+#### Using Custom User-Agent (Optional New Feature)
+
+If you want to set a custom User-Agent for your application:
+
+```kotlin
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        // Set custom User-Agent (optional)
+        NetworkHelper.customUserAgent = "MyApp/1.0.0 (Android ${Build.VERSION.RELEASE})"
+    }
+}
+```
+
+**Recommended Format:**
+```
+AppName/Version (Platform Details) [Optional Additional Info]
+```
+
+**Examples:**
+- `"MyBankApp/2.1.0 (Android 13)"`
+- `"CorporateApp/3.0 (Android 12; Model SM-G998B)"`
+- `"MyApp/1.0.0 (Android 13; Build 42)"`
+
+#### Automatic Bug Fixes (No Action Required)
+
+The following improvements are applied automatically:
+- Malformed JSON with single quotes is now handled gracefully
+- TOTP URI parameters are no longer duplicated
+- All existing functionality continues to work as before
+
+## Known Issues
+
+None identified for this release.
+
+## Additional Notes
+
+- This release is recommended for all applications using the IBM Verify SDK for Android
+- The custom User-Agent feature is particularly useful for applications requiring detailed analytics or debugging
+- JSON normalization improves compatibility with legacy on-premise deployments
+- TOTP URI improvements ensure correct OTP authenticator configuration
+- Extensive test coverage provides confidence in the new functionality
+
+## Links
+
+- [GitHub Release](https://github.com/ibm-verify/verify-sdk-android/releases/tag/3.2.6)
+- [Repository](https://github.com/ibm-verify/verify-sdk-android)
+- [JitPack](https://jitpack.io/#ibm-verify/verify-sdk-android/3.2.6)
+- [SSL Certificate Bypass Documentation](../../docs/SSL_CERTIFICATE_BYPASS.md)
+
+## Support
+
+For issues, questions, or contributions, please visit:
+
+- [GitHub Issues](https://github.com/ibm-verify/verify-sdk-android/issues)
+- [Contributing Guide](../../CONTRIBUTING.md)
+
+---
+
+**Release Date:** June 2026  
+**Version:** 3.2.6  
+**Previous Version:** 3.2.5

--- a/sdk/core/src/androidTest/java/com/ibm/security/verifysdk/core/NetworkHelperTest.kt
+++ b/sdk/core/src/androidTest/java/com/ibm/security/verifysdk/core/NetworkHelperTest.kt
@@ -416,4 +416,124 @@ internal class NetworkHelperTest {
         trustManager.checkClientTrusted(null, null)
         trustManager.checkServerTrusted(null, null)
     }
+
+    @Test
+    fun test_customUserAgent_canBeSetAndRetrieved() {
+        val originalUserAgent = NetworkHelper.customUserAgent
+        try {
+            NetworkHelper.customUserAgent = null
+            assertEquals(null, NetworkHelper.customUserAgent)
+
+            NetworkHelper.customUserAgent = "TestApp/1.0.0"
+            assertEquals("TestApp/1.0.0", NetworkHelper.customUserAgent)
+
+            NetworkHelper.customUserAgent = "TestApp/2.0.0 (Android 13)"
+            assertEquals("TestApp/2.0.0 (Android 13)", NetworkHelper.customUserAgent)
+        } finally {
+            NetworkHelper.customUserAgent = originalUserAgent
+            NetworkHelper.closeClient()
+        }
+    }
+
+    @Test
+    fun test_customUserAgent_changeInvalidatesClient() {
+        NetworkHelper.closeClient()
+        val originalUserAgent = NetworkHelper.customUserAgent
+
+        try {
+            val firstClient = NetworkHelper.getInstance
+            NetworkHelper.customUserAgent = "TestApp/1.0.0"
+            val secondClient = NetworkHelper.getInstance
+
+            assertNotSame(firstClient, secondClient)
+
+            firstClient.close()
+            secondClient.close()
+        } finally {
+            NetworkHelper.customUserAgent = originalUserAgent
+            NetworkHelper.closeClient()
+        }
+    }
+
+    @Test
+    fun test_customUserAgent_sameValueDoesNotInvalidateClient() {
+        NetworkHelper.closeClient()
+        val originalUserAgent = NetworkHelper.customUserAgent
+        val userAgent = "TestApp/1.0.0"
+
+        try {
+            NetworkHelper.customUserAgent = userAgent
+            val firstClient = NetworkHelper.getInstance
+            NetworkHelper.customUserAgent = userAgent
+            val secondClient = NetworkHelper.getInstance
+
+            assertSame(firstClient, secondClient)
+
+            firstClient.close()
+        } finally {
+            NetworkHelper.customUserAgent = originalUserAgent
+            NetworkHelper.closeClient()
+        }
+    }
+
+    @Test
+    fun test_customUserAgent_appliedToSecureClient() {
+        NetworkHelper.closeClient()
+        val originalUserAgent = NetworkHelper.customUserAgent
+
+        try {
+            NetworkHelper.customUserAgent = "TestApp/1.0.0 (Android)"
+            val client = NetworkHelper.getInstance
+
+            // Verify client was created successfully with custom User-Agent
+            assertNotNull(client)
+
+            client.close()
+        } finally {
+            NetworkHelper.customUserAgent = originalUserAgent
+            NetworkHelper.closeClient()
+        }
+    }
+
+    @Test
+    fun test_customUserAgent_appliedToInsecureClient() {
+        val originalUserAgent = NetworkHelper.customUserAgent
+        val originalAllowInsecureSSL = NetworkHelper.allowInsecureSSL
+        NetworkHelper.closeClient()
+
+        try {
+            NetworkHelper.allowInsecureSSL = true
+            NetworkHelper.customUserAgent = "TestApp/1.0.0 (Android)"
+
+            val insecureClient = NetworkHelper.createInsecureClient()
+
+            // Verify insecure client was created successfully with custom User-Agent
+            assertNotNull(insecureClient)
+
+            insecureClient.close()
+        } finally {
+            NetworkHelper.customUserAgent = originalUserAgent
+            NetworkHelper.allowInsecureSSL = originalAllowInsecureSSL
+            NetworkHelper.closeClient()
+        }
+    }
+
+    @Test
+    fun test_customUserAgent_nullValueDoesNotAddHeader() {
+        NetworkHelper.closeClient()
+        val originalUserAgent = NetworkHelper.customUserAgent
+
+        try {
+            NetworkHelper.customUserAgent = null
+            val client = NetworkHelper.getInstance
+
+            // Verify client was created successfully without custom User-Agent
+            assertNotNull(client)
+
+            client.close()
+        } finally {
+            NetworkHelper.customUserAgent = originalUserAgent
+            NetworkHelper.closeClient()
+        }
+    }
 }

--- a/sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt
+++ b/sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt
@@ -198,6 +198,67 @@ object NetworkHelper {
         }
 
     /**
+     * Custom User-Agent header to be included in all HTTP requests made by the SDK.
+     *
+     * When set, this User-Agent string will be added to all HTTP requests made by the SDK,
+     * replacing the default User-Agent provided by the underlying HTTP client (OkHttp/Ktor).
+     *
+     * ## Use Cases
+     * - Identify your application in server logs
+     * - Include app version and platform information
+     * - Meet compliance or analytics requirements
+     * - Debug and troubleshoot API issues
+     *
+     * ## Example
+     * ```kotlin
+     * class MyApplication : Application() {
+     *     override fun onCreate() {
+     *         super.onCreate()
+     *
+     *         // Set custom User-Agent for all SDK requests
+     *         NetworkHelper.customUserAgent = "MyApp/1.0.0 (Android ${Build.VERSION.RELEASE})"
+     *     }
+     * }
+     * ```
+     *
+     * ## Format Recommendations
+     * Follow the standard User-Agent format:
+     * ```
+     * AppName/Version (Platform Details) [Optional Additional Info]
+     * ```
+     *
+     * Examples:
+     * - `"MyBankApp/2.1.0 (Android 13)"`
+     * - `"MyApp/1.0.0 (Android 13; Build 42)"`
+     * - `"CorporateApp/3.0 (Android 12; Model SM-G998B)"`
+     *
+     * ## Thread Safety
+     * This property is thread-safe. Changing it will invalidate and recreate the HTTP client,
+     * ensuring all subsequent requests use the new User-Agent.
+     *
+     * ## Advanced Use Cases
+     * For dynamic or per-request User-Agent logic, use [customInterceptor] instead:
+     * ```kotlin
+     * NetworkHelper.customInterceptor = Interceptor { chain ->
+     *     val userAgent = calculateDynamicUserAgent()
+     *     chain.proceed(chain.request().newBuilder()
+     *         .header("User-Agent", userAgent)
+     *         .build())
+     * }
+     * ```
+     *
+     * @see customInterceptor
+     * @since 3.2.6
+     */
+    var customUserAgent: String? = null
+        set(value) {
+            if (field != value) {
+                field = value
+                invalidateClient()
+            }
+        }
+
+    /**
      * Returns the singleton HttpClient instance.
      *
      * Uses lazy initialization for better performance - the client is only created
@@ -353,6 +414,7 @@ object NetworkHelper {
             readTimeout(readTimeOutMillis, TimeUnit.MILLISECONDS)
             certificatePinner?.let { certificatePinner(it) }
             certificateTransparencyInterceptor?.let { addNetworkInterceptor(it) }
+            createUserAgentInterceptor()?.let { addInterceptor(it) }
             sslContext?.let { sslContext ->
                 trustManager?.let {
                     sslSocketFactory(sslContext.socketFactory, it)
@@ -361,6 +423,25 @@ object NetworkHelper {
             hostnameVerifier?.let { hostnameVerifier(it) }
             customDnsResolver?.let { dns(it) }
         }.build()
+    }
+
+    /**
+     * Creates an OkHttp interceptor that adds a custom User-Agent header to all requests.
+     *
+     * This internal helper method is used by both [createOkHttpClient] and [createInsecureClient]
+     * to ensure consistent User-Agent header injection across all HTTP clients created by the SDK.
+     *
+     * @return An [Interceptor] that adds the User-Agent header, or null if [customUserAgent] is not set
+     */
+    private fun createUserAgentInterceptor(): Interceptor? {
+        return customUserAgent?.let { userAgent ->
+            Interceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header("User-Agent", userAgent)
+                    .build()
+                chain.proceed(request)
+            }
+        }
     }
 
     /**
@@ -468,6 +549,7 @@ object NetworkHelper {
                 followSslRedirects(followSslRedirects)
                 customInterceptor?.let { addInterceptor(it) }
                 customLoggingInterceptor?.let { addInterceptor(it) }
+                createUserAgentInterceptor()?.let { addInterceptor(it) }
             }.build()
 
             HttpClient(OkHttp) {

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/OTPAuthenticatorTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/OTPAuthenticatorTest.kt
@@ -507,4 +507,159 @@ class OTPAuthenticatorTest {
         assertEquals(digits, passcode?.length)
         assertTrue("Passcode should contain only digits", passcode?.all { it.isDigit() } == true)
     }
+
+    // ========================================
+    // HMAC Algorithm Tests with QR Code URIs
+    // ========================================
+
+    @Test
+    fun fromQRScan_withTOTPAndHmacSHA1_shouldCreateAuthenticator() {
+        // Given
+        val qrCode = "otpauth://totp/TestService:user@example.com?secret=JBSWY3DPEHPK3PXP&algorithm=HmacSHA1&digits=6&period=30"
+
+        // When
+        val authenticator = OTPAuthenticator.fromQRScan(qrCode)
+
+        // Then
+        assertNotNull("Authenticator should be created", authenticator)
+        assertNotNull("TOTP should be present", authenticator?.totp)
+        assertEquals("HmacSHA1", authenticator?.totp?.algorithm.toString())
+        
+        // Verify passcode generation works
+        val passcode = authenticator?.totp?.generatePasscode()
+        assertNotNull("Passcode should be generated", passcode)
+        assertEquals(6, passcode?.length)
+        assertTrue("Passcode should contain only digits", passcode?.all { it.isDigit() } == true)
+    }
+
+    @Test
+    fun fromQRScan_withTOTPAndHmacSHA256_shouldCreateAuthenticator() {
+        // Given
+        val qrCode = "otpauth://totp/TestService:user@example.com?secret=JBSWY3DPEHPK3PXP&algorithm=HmacSHA256&digits=6&period=30"
+
+        // When
+        val authenticator = OTPAuthenticator.fromQRScan(qrCode)
+
+        // Then
+        assertNotNull("Authenticator should be created", authenticator)
+        assertNotNull("TOTP should be present", authenticator?.totp)
+        assertEquals("HmacSHA256", authenticator?.totp?.algorithm.toString())
+        
+        // Verify passcode generation works
+        val passcode = authenticator?.totp?.generatePasscode()
+        assertNotNull("Passcode should be generated", passcode)
+        assertEquals(6, passcode?.length)
+        assertTrue("Passcode should contain only digits", passcode?.all { it.isDigit() } == true)
+    }
+
+    @Test
+    fun fromQRScan_withTOTPAndHmacSHA512_shouldCreateAuthenticator() {
+        // Given
+        val qrCode = "otpauth://totp/TestService:user@example.com?secret=JBSWY3DPEHPK3PXP&algorithm=HmacSHA512&digits=6&period=30"
+
+        // When
+        val authenticator = OTPAuthenticator.fromQRScan(qrCode)
+
+        // Then
+        assertNotNull("Authenticator should be created", authenticator)
+        assertNotNull("TOTP should be present", authenticator?.totp)
+        assertEquals("HmacSHA512", authenticator?.totp?.algorithm.toString())
+        
+        // Verify passcode generation works
+        val passcode = authenticator?.totp?.generatePasscode()
+        assertNotNull("Passcode should be generated", passcode)
+        assertEquals(6, passcode?.length)
+        assertTrue("Passcode should contain only digits", passcode?.all { it.isDigit() } == true)
+    }
+
+    @Test
+    fun fromQRScan_withHOTPAndHmacSHA1_shouldCreateAuthenticator() {
+        // Given
+        val qrCode = "otpauth://hotp/TestService:user@example.com?secret=ON6MJUIM4MXYVLN3&algorithm=HmacSHA1&digits=6&counter=0"
+
+        // When
+        val authenticator = OTPAuthenticator.fromQRScan(qrCode)
+
+        // Then
+        assertNotNull("Authenticator should be created", authenticator)
+        assertNotNull("HOTP should be present", authenticator?.hotp)
+        assertEquals("HmacSHA1", authenticator?.hotp?.algorithm.toString())
+        
+        // Verify passcode generation works
+        val passcode = authenticator?.hotp?.generatePasscode(incrementCounter = false)
+        assertNotNull("Passcode should be generated", passcode)
+        assertEquals(6, passcode?.length)
+        assertTrue("Passcode should contain only digits", passcode?.all { it.isDigit() } == true)
+    }
+
+    @Test
+    fun fromQRScan_withHOTPAndHmacSHA256_shouldCreateAuthenticator() {
+        // Given
+        val qrCode = "otpauth://hotp/TestService:user@example.com?secret=ON6MJUIM4MXYVLN3&algorithm=HmacSHA256&digits=6&counter=0"
+
+        // When
+        val authenticator = OTPAuthenticator.fromQRScan(qrCode)
+
+        // Then
+        assertNotNull("Authenticator should be created", authenticator)
+        assertNotNull("HOTP should be present", authenticator?.hotp)
+        assertEquals("HmacSHA256", authenticator?.hotp?.algorithm.toString())
+        
+        // Verify passcode generation works
+        val passcode = authenticator?.hotp?.generatePasscode(incrementCounter = false)
+        assertNotNull("Passcode should be generated", passcode)
+        assertEquals(6, passcode?.length)
+        assertTrue("Passcode should contain only digits", passcode?.all { it.isDigit() } == true)
+    }
+
+    @Test
+    fun fromQRScan_withHOTPAndHmacSHA512_shouldCreateAuthenticator() {
+        // Given
+        val qrCode = "otpauth://hotp/TestService:user@example.com?secret=ON6MJUIM4MXYVLN3&algorithm=HmacSHA512&digits=6&counter=0"
+
+        // When
+        val authenticator = OTPAuthenticator.fromQRScan(qrCode)
+
+        // Then
+        assertNotNull("Authenticator should be created", authenticator)
+        assertNotNull("HOTP should be present", authenticator?.hotp)
+        assertEquals("HmacSHA512", authenticator?.hotp?.algorithm.toString())
+        
+        // Verify passcode generation works
+        val passcode = authenticator?.hotp?.generatePasscode(incrementCounter = false)
+        assertNotNull("Passcode should be generated", passcode)
+        assertEquals(6, passcode?.length)
+        assertTrue("Passcode should contain only digits", passcode?.all { it.isDigit() } == true)
+    }
+
+
+    @Test
+    fun fromQRScan_withBOIUATDataAndHmacSHA512InURL_shouldCreateAuthenticatorWith8Digits() {
+        // Given - BOI_UAT data with algorithm and digits in the QR code URL
+        val qrCode = "otpauth://totp/BOI_UAT:rs1005312neu?secret=LLKDX636FQCGIH3OOK646YEGYP6AB6ZH&issuer=BOI_UAT&algorithm=HmacSHA512&digits=8&period=30"
+
+        // When
+        val authenticator = OTPAuthenticator.fromQRScan(qrCode)
+
+        // Then
+        assertNotNull("Authenticator should be created", authenticator)
+        assertEquals("BOI_UAT", authenticator?.serviceName)
+        assertEquals("rs1005312neu", authenticator?.accountName)
+        assertNotNull("TOTP factor should be present", authenticator?.totp)
+        assertNull("HOTP factor should not be present", authenticator?.hotp)
+
+        // Verify TOTP configuration matches the QR code parameters
+        authenticator?.totp?.let { totp ->
+            assertEquals("Secret should match", "LLKDX636FQCGIH3OOK646YEGYP6AB6ZH", totp.secret)
+            assertEquals("Algorithm should be HmacSHA512", "HmacSHA512", totp.algorithm.toString())
+            assertEquals("Digits should be 8", 8, totp.digits)
+            assertEquals("Period should be 30", 30, totp.period)
+
+            // Verify that a passcode can be generated
+            val passcode = totp.generatePasscode()
+            assertNotNull("Passcode should be generated", passcode)
+            assertEquals("Passcode length should be 8 digits", 8, passcode.length)
+            assertTrue("Passcode should contain only digits", passcode.all { it.isDigit() })
+        }
+    }
 }

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorIntegrationTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorIntegrationTest.kt
@@ -860,6 +860,134 @@ class OnPremiseAuthenticatorIntegrationTest {
         }
 
         httpClient.close()
+
+    /**
+     * Test Case: Fetch Pending Transaction with Legacy Single-Quoted JSON Format
+     * 
+     * This test verifies that the SDK correctly handles the legacy format where
+     * mmfa.request.extras contains single-quoted JSON (from previous versions).
+     * 
+     * Real-world example from BOI_UAT system:
+     * {"values":["{'denyReasonEnabled':'false'}"],"uri":"mmfa:request:extras"}
+     */
+    @Test
+    fun testFetchPendingTransaction_withLegacySingleQuotedJSON_shouldParseDenyReasonEnabled(): Unit = runBlocking {
+        val now = kotlin.time.Clock.System.now()
+        val creationTime = now.toString()
+        val lastActivityTime = now.toString()
+        
+        val mockEngine = MockEngine { request ->
+            when {
+                request.url.encodedPath.contains("/scim/Me") -> {
+                    respond(
+                        content = """
+                        {
+                          "meta": {
+                            "location": "https://mmfa-mobile.securitypoc.com/scim/Users/chageman@au1.ibm.com",
+                            "resourceType": "User"
+                          },
+                          "schemas": [
+                            "urn:ietf:params:scim:schemas:core:2.0:User",
+                            "urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Transaction"
+                          ],
+                          "id": "chageman@au1.ibm.com",
+                          "urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Transaction": {
+                            "attributesPending": [
+                              {
+                                "dataType": "String",
+                                "values": ["Please log me in: chageman@au1.ibm.com"],
+                                "name": "mmfa.request.context.message",
+                                "uri": "mmfa:request:context:message",
+                                "transactionId": "9661f686-89de-45a2-9500-83abe6d27db0"
+                              },
+                              {
+                                "dataType": "String",
+                                "values": ["Please log me in: chageman@au1.ibm.com"],
+                                "name": "mmfa.request.push.message",
+                                "uri": "mmfa:request:push:message",
+                                "transactionId": "9661f686-89de-45a2-9500-83abe6d27db0"
+                              },
+                              {
+                                "dataType": "String",
+                                "values": ["{'denyReasonEnabled':'false'}"],
+                                "name": "mmfa.request.extras",
+                                "uri": "mmfa:request:extras",
+                                "transactionId": "9661f686-89de-45a2-9500-83abe6d27db0"
+                              },
+                              {
+                                "dataType": "String",
+                                "values": ["false"],
+                                "name": "mmfa.request.push.notification.sent",
+                                "uri": "mmfa:request:push:notification:sent",
+                                "transactionId": "9661f686-89de-45a2-9500-83abe6d27db0"
+                              },
+                              {
+                                "dataType": "String",
+                                "values": ["uuid014f78f2-c1fd-4b17-93f2-a808f09215bc"],
+                                "name": "mmfa.request.authenticator.id",
+                                "uri": "mmfa:request:authenticator:id",
+                                "transactionId": "9661f686-89de-45a2-9500-83abe6d27db0"
+                              }
+                            ],
+                            "transactionsPending": [{
+                              "authnPolicyAction": "POST",
+                              "txnStatus": "PENDING",
+                              "creationTime": "$creationTime",
+                              "requestUrl": "https://mmfa-mobile.securitypoc.com:443/mga/sps/apiauthsvc?MmfaTransactionId=9661F686-89DE-45A2-9500-83ABE6D27DB0",
+                              "authnPolicyURI": "urn:ibm:security:authentication:asf:mmfa_response_userpresence",
+                              "lastActivityTime": "$lastActivityTime",
+                              "transactionId": "9661f686-89de-45a2-9500-83abe6d27db0"
+                            }]
+                          },
+                          "userName": "chageman@au1.ibm.com"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(
+                            HttpHeaders.ContentType to listOf("application/scim+json"),
+                            HttpHeaders.CacheControl to listOf("private, max-age=0, no-cache")
+                        )
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine)
+        val service = OnPremiseAuthenticatorService(
+            _accessToken = "test_access_token",
+            _refreshUri = URL("https://mmfa-mobile.securitypoc.com/mga/sps/oauth/oauth20/token"),
+            _transactionUri = URL("https://mmfa-mobile.securitypoc.com/scim/Me?attributes=urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Transaction:transactionsPending,urn:ietf:params:scim:schemas:extension:isam:1.0:MMFA:Transaction:attributesPending"),
+            _clientId = "AuthenticatorClient",
+            _authenticatorId = "client-id",
+            _serverAuthenticatorId = "uuid014f78f2-c1fd-4b17-93f2-a808f09215bc",
+            httpClient = httpClient
+        )
+
+        val result = service.nextTransaction()
+
+        result.onFailure { error ->
+            throw AssertionError("Fetch pending transaction with legacy format failed: ${error.message}", error)
+        }
+
+        assertTrue("Fetch pending transaction should succeed", result.isSuccess)
+        result.onSuccess { (transactions, count) ->
+            assertEquals("Should have 1 transaction in total count", 1, count)
+            assertEquals("Should return 1 transaction in list", 1, transactions.size)
+
+            val transaction = transactions.first()
+            assertEquals("9661f686-89de-45a2-9500-83abe6d27db0", transaction.id)
+            assertEquals("Please log me in: chageman@au1.ibm.com", transaction.message)
+
+            // Verify denyReasonEnabled was correctly parsed from legacy single-quoted JSON
+            val attributes = transaction.additionalData
+            assertNotNull("Transaction attributes should not be null", attributes)
+            assertTrue("Should have deny reason attribute", attributes.containsKey(TransactionAttribute.DenyReason))
+            assertEquals("false", attributes[TransactionAttribute.DenyReason])
+        }
+
+        httpClient.close()
+    }
     }
 }
 

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProviderTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProviderTest.kt
@@ -1611,5 +1611,622 @@ class OnPremiseRegistrationProviderTest {
                  exception.message?.contains("allowInsecureSSL", ignoreCase = true) == true)
             )
         }
+
+    /**
+     * Test TOTP enrollment with secretKeyUrl containing no existing parameters.
+     * 
+     * Verifies that digits, period, and algorithm are added to the URI.
+     */
+    @Test
+    fun testEnrollOneTimePasscode_WithNoExistingParameters() = runTest {
+        val qrCodeJson = """
+        {
+            "code": "test_code",
+            "details_url": "https://test.example.com/mga/sps/mmfa/user/mgmt/details",
+            "client_id": "AuthenticatorClient",
+            "options": "ignoreSslCerts=false"
+        }
+        """.trimIndent()
+
+        val mockEngine = MockEngine { request ->
+            when {
+                request.url.encodedPath.contains("/details") -> {
+                    respond(
+                        content = """
+                        {
+                          "authntrxn_endpoint": "https://test.example.com/scim/Me",
+                          "metadata": {"service_name": "Test Service"},
+                          "discovery_mechanisms": ["urn:ibm:security:authentication:asf:mechanism:totp"],
+                          "enrollment_endpoint": "https://test.example.com/scim/Me",
+                          "qrlogin_endpoint": "https://test.example.com/mga/sps/apiauthsvc/policy/qrcode_response",
+                          "hotp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/hotp",
+                          "totp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/totp",
+                          "version": "11.0.1.0",
+                          "token_endpoint": "https://test.example.com/mga/sps/oauth/oauth20/token"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.url.encodedPath.contains("/oauth20/token") -> {
+                    respond(
+                        content = """
+                        {
+                          "access_token": "test_access_token",
+                          "refresh_token": "test_refresh_token",
+                          "scope": "mmfaAuthn",
+                          "authenticator_id": "test-auth-id",
+                          "token_type": "bearer",
+                          "display_name": "testuser@example.com",
+                          "expires_in": 3599
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.url.encodedPath.contains("/otp/totp") -> {
+                    respond(
+                        content = """
+                        {
+                          "period": "30",
+                          "secretKeyUrl": "otpauth://totp/TestService:user@example.com?secret=JBSWY3DPEHPK3PXP&issuer=TestService",
+                          "secretKey": "JBSWY3DPEHPK3PXP",
+                          "digits": "6",
+                          "username": "user@example.com",
+                          "algorithm": "HmacSHA1"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = true
+                })
+            }
+        }
+
+        val provider = OnPremiseRegistrationProvider(qrCodeJson)
+        val initiateResult = provider.initiate("testuser@example.com", "test_push_token", null, httpClient)
+        
+        assertTrue("Initiate should succeed", initiateResult.isSuccess)
+        assertTrue("Should be able to enroll TOTP", provider.canEnrollOneTimePasscode)
+
+        val otpAuthenticator = provider.enrollOneTimePasscode(httpClient)
+        
+        assertNotNull("OTP authenticator should be created", otpAuthenticator)
+        assertNotNull("TOTP should be present", otpAuthenticator.totp)
+        assertEquals("JBSWY3DPEHPK3PXP", otpAuthenticator.totp?.secret)
+        assertEquals(6, otpAuthenticator.totp?.digits)
+        assertEquals(30, otpAuthenticator.totp?.period)
+
+        httpClient.close()
+    }
+
+    /**
+     * Test TOTP enrollment with secretKeyUrl already containing digits parameter.
+     * 
+     * Verifies that existing digits parameter is preserved and not duplicated.
+     */
+    @Test
+    fun testEnrollOneTimePasscode_WithExistingDigitsParameter() = runTest {
+        val qrCodeJson = """
+        {
+            "code": "test_code",
+            "details_url": "https://test.example.com/mga/sps/mmfa/user/mgmt/details",
+            "client_id": "AuthenticatorClient",
+            "options": "ignoreSslCerts=false"
+        }
+        """.trimIndent()
+
+        val mockEngine = MockEngine { request ->
+            when {
+                request.url.encodedPath.contains("/details") -> {
+                    respond(
+                        content = """
+                        {
+                          "authntrxn_endpoint": "https://test.example.com/scim/Me",
+                          "metadata": {"service_name": "Test Service"},
+                          "discovery_mechanisms": ["urn:ibm:security:authentication:asf:mechanism:totp"],
+                          "enrollment_endpoint": "https://test.example.com/scim/Me",
+                          "qrlogin_endpoint": "https://test.example.com/mga/sps/apiauthsvc/policy/qrcode_response",
+                          "hotp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/hotp",
+                          "totp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/totp",
+                          "version": "11.0.1.0",
+                          "token_endpoint": "https://test.example.com/mga/sps/oauth/oauth20/token"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.url.encodedPath.contains("/oauth20/token") -> {
+                    respond(
+                        content = """
+                        {
+                          "access_token": "test_access_token",
+                          "refresh_token": "test_refresh_token",
+                          "scope": "mmfaAuthn",
+                          "authenticator_id": "test-auth-id",
+                          "token_type": "bearer",
+                          "display_name": "testuser@example.com",
+                          "expires_in": 3599
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.url.encodedPath.contains("/otp/totp") -> {
+                    respond(
+                        content = """
+                        {
+                          "period": "30",
+                          "secretKeyUrl": "otpauth://totp/TestService:user@example.com?secret=JBSWY3DPEHPK3PXP&issuer=TestService&digits=8",
+                          "secretKey": "JBSWY3DPEHPK3PXP",
+                          "digits": "6",
+                          "username": "user@example.com",
+                          "algorithm": "HmacSHA1"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = true
+                })
+            }
+        }
+
+        val provider = OnPremiseRegistrationProvider(qrCodeJson)
+        val initiateResult = provider.initiate("testuser@example.com", "test_push_token", null, httpClient)
+        
+        assertTrue("Initiate should succeed", initiateResult.isSuccess)
+
+        val otpAuthenticator = provider.enrollOneTimePasscode(httpClient)
+        
+        assertNotNull("OTP authenticator should be created", otpAuthenticator)
+        assertNotNull("TOTP should be present", otpAuthenticator.totp)
+        // Should use the digits from secretKeyUrl (8), not from separate field (6)
+        assertEquals(8, otpAuthenticator.totp?.digits)
+        assertEquals(30, otpAuthenticator.totp?.period)
+
+        httpClient.close()
+    }
+
+    /**
+     * Test TOTP enrollment with secretKeyUrl already containing period parameter.
+     * 
+     * Verifies that existing period parameter is preserved and not duplicated.
+     */
+    @Test
+    fun testEnrollOneTimePasscode_WithExistingPeriodParameter() = runTest {
+        val qrCodeJson = """
+        {
+            "code": "test_code",
+            "details_url": "https://test.example.com/mga/sps/mmfa/user/mgmt/details",
+            "client_id": "AuthenticatorClient",
+            "options": "ignoreSslCerts=false"
+        }
+        """.trimIndent()
+
+        val mockEngine = MockEngine { request ->
+            when {
+                request.url.encodedPath.contains("/details") -> {
+                    respond(
+                        content = """
+                        {
+                          "authntrxn_endpoint": "https://test.example.com/scim/Me",
+                          "metadata": {"service_name": "Test Service"},
+                          "discovery_mechanisms": ["urn:ibm:security:authentication:asf:mechanism:totp"],
+                          "enrollment_endpoint": "https://test.example.com/scim/Me",
+                          "qrlogin_endpoint": "https://test.example.com/mga/sps/apiauthsvc/policy/qrcode_response",
+                          "hotp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/hotp",
+                          "totp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/totp",
+                          "version": "11.0.1.0",
+                          "token_endpoint": "https://test.example.com/mga/sps/oauth/oauth20/token"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.url.encodedPath.contains("/oauth20/token") -> {
+                    respond(
+                        content = """
+                        {
+                          "access_token": "test_access_token",
+                          "refresh_token": "test_refresh_token",
+                          "scope": "mmfaAuthn",
+                          "authenticator_id": "test-auth-id",
+                          "token_type": "bearer",
+                          "display_name": "testuser@example.com",
+                          "expires_in": 3599
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.url.encodedPath.contains("/otp/totp") -> {
+                    respond(
+                        content = """
+                        {
+                          "period": "30",
+                          "secretKeyUrl": "otpauth://totp/TestService:user@example.com?secret=JBSWY3DPEHPK3PXP&issuer=TestService&period=60",
+                          "secretKey": "JBSWY3DPEHPK3PXP",
+                          "digits": "6",
+                          "username": "user@example.com",
+                          "algorithm": "HmacSHA1"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = true
+                })
+            }
+        }
+
+        val provider = OnPremiseRegistrationProvider(qrCodeJson)
+        val initiateResult = provider.initiate("testuser@example.com", "test_push_token", null, httpClient)
+        
+        assertTrue("Initiate should succeed", initiateResult.isSuccess)
+
+        val otpAuthenticator = provider.enrollOneTimePasscode(httpClient)
+        
+        assertNotNull("OTP authenticator should be created", otpAuthenticator)
+        assertNotNull("TOTP should be present", otpAuthenticator.totp)
+        assertEquals(6, otpAuthenticator.totp?.digits)
+        // Should use the period from secretKeyUrl (60), not from separate field (30)
+        assertEquals(60, otpAuthenticator.totp?.period)
+
+        httpClient.close()
+    }
+
+    /**
+     * Test TOTP enrollment with secretKeyUrl already containing algorithm parameter.
+     * 
+     * Verifies that existing algorithm parameter is preserved and not duplicated.
+     */
+    @Test
+    fun testEnrollOneTimePasscode_WithExistingAlgorithmParameter() = runTest {
+        val qrCodeJson = """
+        {
+            "code": "test_code",
+            "details_url": "https://test.example.com/mga/sps/mmfa/user/mgmt/details",
+            "client_id": "AuthenticatorClient",
+            "options": "ignoreSslCerts=false"
+        }
+        """.trimIndent()
+
+        val mockEngine = MockEngine { request ->
+            when {
+                request.url.encodedPath.contains("/details") -> {
+                    respond(
+                        content = """
+                        {
+                          "authntrxn_endpoint": "https://test.example.com/scim/Me",
+                          "metadata": {"service_name": "Test Service"},
+                          "discovery_mechanisms": ["urn:ibm:security:authentication:asf:mechanism:totp"],
+                          "enrollment_endpoint": "https://test.example.com/scim/Me",
+                          "qrlogin_endpoint": "https://test.example.com/mga/sps/apiauthsvc/policy/qrcode_response",
+                          "hotp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/hotp",
+                          "totp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/totp",
+                          "version": "11.0.1.0",
+                          "token_endpoint": "https://test.example.com/mga/sps/oauth/oauth20/token"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.url.encodedPath.contains("/oauth20/token") -> {
+                    respond(
+                        content = """
+                        {
+                          "access_token": "test_access_token",
+                          "refresh_token": "test_refresh_token",
+                          "scope": "mmfaAuthn",
+                          "authenticator_id": "test-auth-id",
+                          "token_type": "bearer",
+                          "display_name": "testuser@example.com",
+                          "expires_in": 3599
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.url.encodedPath.contains("/otp/totp") -> {
+                    respond(
+                        content = """
+                        {
+                          "period": "30",
+                          "secretKeyUrl": "otpauth://totp/TestService:user@example.com?secret=JBSWY3DPEHPK3PXP&issuer=TestService&algorithm=SHA256",
+                          "secretKey": "JBSWY3DPEHPK3PXP",
+                          "digits": "6",
+                          "username": "user@example.com",
+                          "algorithm": "HmacSHA1"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = true
+                })
+            }
+        }
+
+        val provider = OnPremiseRegistrationProvider(qrCodeJson)
+        val initiateResult = provider.initiate("testuser@example.com", "test_push_token", null, httpClient)
+        
+        assertTrue("Initiate should succeed", initiateResult.isSuccess)
+
+        val otpAuthenticator = provider.enrollOneTimePasscode(httpClient)
+        
+        assertNotNull("OTP authenticator should be created", otpAuthenticator)
+        assertNotNull("TOTP should be present", otpAuthenticator.totp)
+        assertEquals(6, otpAuthenticator.totp?.digits)
+        assertEquals(30, otpAuthenticator.totp?.period)
+        // Should use the algorithm from secretKeyUrl (SHA256), not from separate field (HmacSHA1)
+        assertEquals(com.ibm.security.verifysdk.mfa.HashAlgorithmType.SHA256, otpAuthenticator.totp?.algorithm)
+
+        httpClient.close()
+    }
+
+    /**
+     * Test TOTP enrollment with secretKeyUrl already containing all parameters.
+     * 
+     * Verifies that all existing parameters are preserved and none are duplicated.
+     */
+    @Test
+    fun testEnrollOneTimePasscode_WithAllExistingParameters() = runTest {
+        val qrCodeJson = """
+        {
+            "code": "test_code",
+            "details_url": "https://test.example.com/mga/sps/mmfa/user/mgmt/details",
+            "client_id": "AuthenticatorClient",
+            "options": "ignoreSslCerts=false"
+        }
+        """.trimIndent()
+
+        val mockEngine = MockEngine { request ->
+            when {
+                request.url.encodedPath.contains("/details") -> {
+                    respond(
+                        content = """
+                        {
+                          "authntrxn_endpoint": "https://test.example.com/scim/Me",
+                          "metadata": {"service_name": "Test Service"},
+                          "discovery_mechanisms": ["urn:ibm:security:authentication:asf:mechanism:totp"],
+                          "enrollment_endpoint": "https://test.example.com/scim/Me",
+                          "qrlogin_endpoint": "https://test.example.com/mga/sps/apiauthsvc/policy/qrcode_response",
+                          "hotp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/hotp",
+                          "totp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/totp",
+                          "version": "11.0.1.0",
+                          "token_endpoint": "https://test.example.com/mga/sps/oauth/oauth20/token"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.url.encodedPath.contains("/oauth20/token") -> {
+                    respond(
+                        content = """
+                        {
+                          "access_token": "test_access_token",
+                          "refresh_token": "test_refresh_token",
+                          "scope": "mmfaAuthn",
+                          "authenticator_id": "test-auth-id",
+                          "token_type": "bearer",
+                          "display_name": "testuser@example.com",
+                          "expires_in": 3599
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.url.encodedPath.contains("/otp/totp") -> {
+                    respond(
+                        content = """
+                        {
+                          "period": "30",
+                          "secretKeyUrl": "otpauth://totp/TestService:user@example.com?secret=JBSWY3DPEHPK3PXP&issuer=TestService&digits=8&period=60&algorithm=SHA512",
+                          "secretKey": "JBSWY3DPEHPK3PXP",
+                          "digits": "6",
+                          "username": "user@example.com",
+                          "algorithm": "HmacSHA1"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = true
+                })
+            }
+        }
+
+        val provider = OnPremiseRegistrationProvider(qrCodeJson)
+        val initiateResult = provider.initiate("testuser@example.com", "test_push_token", null, httpClient)
+        
+        assertTrue("Initiate should succeed", initiateResult.isSuccess)
+
+        val otpAuthenticator = provider.enrollOneTimePasscode(httpClient)
+        
+        assertNotNull("OTP authenticator should be created", otpAuthenticator)
+        assertNotNull("TOTP should be present", otpAuthenticator.totp)
+        // All values should come from secretKeyUrl, not separate fields
+        assertEquals(8, otpAuthenticator.totp?.digits)
+        assertEquals(60, otpAuthenticator.totp?.period)
+        assertEquals(com.ibm.security.verifysdk.mfa.HashAlgorithmType.SHA512, otpAuthenticator.totp?.algorithm)
+
+        httpClient.close()
+    }
+
+    /**
+     * Test TOTP enrollment with BOI_UAT data containing HmacSHA512 and 8 digits.
+     *
+     * This test verifies that when the server returns a TOTP enrollment response
+     * with algorithm and digits specified in the JSON (not in the URL), the
+     * OTPAuthenticator is created correctly by parsing the secretKeyUrl.
+     *
+     * Based on real-world BOI_UAT system data.
+     */
+    @Test
+    fun testEnrollOneTimePasscode_WithBOIUATDataAndHmacSHA512_shouldCreateAuthenticatorWith8Digits() = runTest {
+        val qrCodeJson = """
+        {
+            "code": "test_code",
+            "details_url": "https://test.example.com/mga/sps/mmfa/user/mgmt/details",
+            "client_id": "AuthenticatorClient",
+            "options": "ignoreSslCerts=false"
+        }
+        """.trimIndent()
+
+        val mockEngine = MockEngine { request ->
+            when {
+                request.url.encodedPath.contains("/details") -> {
+                    respond(
+                        content = """
+                        {
+                          "authntrxn_endpoint": "https://test.example.com/scim/Me",
+                          "metadata": {"service_name": "BOI_UAT"},
+                          "discovery_mechanisms": ["urn:ibm:security:authentication:asf:mechanism:totp"],
+                          "enrollment_endpoint": "https://test.example.com/scim/Me",
+                          "qrlogin_endpoint": "https://test.example.com/mga/sps/apiauthsvc/policy/qrcode_response",
+                          "hotp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/hotp",
+                          "totp_shared_secret_endpoint": "https://test.example.com/mga/sps/mga/user/mgmt/otp/totp",
+                          "version": "11.0.1.0",
+                          "token_endpoint": "https://test.example.com/mga/sps/oauth/oauth20/token"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.url.encodedPath.contains("/oauth20/token") -> {
+                    respond(
+                        content = """
+                        {
+                          "access_token": "test_access_token",
+                          "refresh_token": "test_refresh_token",
+                          "scope": "mmfaAuthn",
+                          "authenticator_id": "test-auth-id",
+                          "token_type": "bearer",
+                          "display_name": "rs1005312neu",
+                          "expires_in": 3599
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                request.url.encodedPath.contains("/otp/totp") -> {
+                    // Real-world BOI_UAT response with HmacSHA512 and 8 digits
+                    respond(
+                        content = """
+                        {
+                           "period":"30",
+                           "secretKeyUrl":"otpauth://totp/BOI_UAT:rs1005312neu?secret=LLKDX636FQCGIH3OOK646YEGYP6AB6ZH&issuer=BOI_UAT&algorithm=SHA512&digits=8",
+                           "secretKey":"LLKDX636FQCGIH3OOK646YEGYP6AB6ZH",
+                           "digits":"8",
+                           "username":"rs1005312neu",
+                           "algorithm":"HmacSHA512"
+                        }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val httpClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = true
+                })
+            }
+        }
+
+        val provider = OnPremiseRegistrationProvider(qrCodeJson)
+        val initiateResult = provider.initiate("rs1005312neu", "test_push_token", null, httpClient)
+        
+        assertTrue("Initiate should succeed", initiateResult.isSuccess)
+        assertTrue("Should be able to enroll TOTP", provider.canEnrollOneTimePasscode)
+
+        val otpAuthenticator = provider.enrollOneTimePasscode(httpClient)
+        
+        assertNotNull("OTP authenticator should be created", otpAuthenticator)
+        assertEquals("BOI_UAT", otpAuthenticator.serviceName)
+        assertEquals("rs1005312neu", otpAuthenticator.accountName)
+        assertNotNull("TOTP should be present", otpAuthenticator.totp)
+        assertNull("HOTP should not be present", otpAuthenticator.hotp)
+        
+        // Verify TOTP configuration from secretKeyUrl (which includes algorithm and digits)
+        otpAuthenticator.totp?.let { totp ->
+            assertEquals("LLKDX636FQCGIH3OOK646YEGYP6AB6ZH", totp.secret)
+            assertEquals(8, totp.digits)
+            assertEquals(30, totp.period)
+            assertEquals(com.ibm.security.verifysdk.mfa.HashAlgorithmType.SHA512, totp.algorithm)
+            
+            // Verify that a passcode can be generated
+            val passcode = totp.generatePasscode()
+            assertNotNull("Passcode should be generated", passcode)
+            assertEquals(8, passcode.length)
+            assertTrue("Passcode should contain only digits", passcode.all { it.isDigit() })
+        }
+
+        httpClient.close()
+    }
     }
 }

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProviderTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProviderTest.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -1611,6 +1612,7 @@ class OnPremiseRegistrationProviderTest {
                  exception.message?.contains("allowInsecureSSL", ignoreCase = true) == true)
             )
         }
+    }
 
     /**
      * Test TOTP enrollment with secretKeyUrl containing no existing parameters.
@@ -2227,6 +2229,5 @@ class OnPremiseRegistrationProviderTest {
         }
 
         httpClient.close()
-    }
     }
 }

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/model/onprem/TransactionResultTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/model/onprem/TransactionResultTest.kt
@@ -670,6 +670,7 @@ class TransactionResultTest {
         // Then
         assertNotNull(jsonElement["denyReasonEnabled"])
         assertEquals("true", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
+    }
 
     @Test
     fun attributeInfo_withLegacySingleQuotedJSON_booleanFalse_shouldParseCorrectly() {
@@ -751,7 +752,6 @@ class TransactionResultTest {
         // Then
         assertNotNull(jsonElement["denyReasonEnabled"])
         assertEquals("false", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
-    }
     }
 }
 

--- a/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/model/onprem/TransactionResultTest.kt
+++ b/sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/model/onprem/TransactionResultTest.kt
@@ -628,6 +628,131 @@ class TransactionResultTest {
         assertEquals("99", jsonElement["correlationValue"]?.jsonPrimitive?.content)
         assertEquals("true", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
     }
+
+    @Test
+    fun attributeInfo_withLegacySingleQuotedJSON_shouldParseCorrectly() {
+        // Given - Legacy format with single quotes (from previous version)
+        // This format is seen in real-world BOI_UAT data
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{'denyReasonEnabled':'false'}"),
+            uri = "mmfa:request:extras",
+            transactionId = "9661f686-89de-45a2-9500-83abe6d27db0"
+        )
+
+        // When - Normalize single quotes to double quotes before parsing
+        val jsonString = attribute.values.first()
+        val normalizedJsonString = jsonString.replace('\'', '"')
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(normalizedJsonString).jsonObject
+
+        // Then
+        assertNotNull(jsonElement["denyReasonEnabled"])
+        assertEquals("false", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun attributeInfo_withLegacySingleQuotedJSON_denyReasonTrue_shouldParseCorrectly() {
+        // Given - Legacy format with single quotes and denyReasonEnabled = true
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{'denyReasonEnabled':'true'}"),
+            uri = "mmfa:request:extras",
+            transactionId = "test-id"
+        )
+
+        // When - Normalize single quotes to double quotes before parsing
+        val jsonString = attribute.values.first()
+        val normalizedJsonString = jsonString.replace('\'', '"')
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(normalizedJsonString).jsonObject
+
+        // Then
+        assertNotNull(jsonElement["denyReasonEnabled"])
+        assertEquals("true", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
+
+    @Test
+    fun attributeInfo_withLegacySingleQuotedJSON_booleanFalse_shouldParseCorrectly() {
+        // Given - Legacy format with single quotes and boolean false (not string)
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{'denyReasonEnabled':false}"),
+            uri = "mmfa:request:extras",
+            transactionId = "test-id"
+        )
+
+        // When - Normalize single quotes to double quotes before parsing
+        val jsonString = attribute.values.first()
+        val normalizedJsonString = jsonString.replace('\'', '"')
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(normalizedJsonString).jsonObject
+
+        // Then
+        assertNotNull(jsonElement["denyReasonEnabled"])
+        assertEquals("false", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun attributeInfo_withLegacySingleQuotedJSON_booleanTrue_shouldParseCorrectly() {
+        // Given - Legacy format with single quotes and boolean true (not string)
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{'denyReasonEnabled':true}"),
+            uri = "mmfa:request:extras",
+            transactionId = "test-id"
+        )
+
+        // When - Normalize single quotes to double quotes before parsing
+        val jsonString = attribute.values.first()
+        val normalizedJsonString = jsonString.replace('\'', '"')
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(normalizedJsonString).jsonObject
+
+        // Then
+        assertNotNull(jsonElement["denyReasonEnabled"])
+        assertEquals("true", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun attributeInfo_withDenyReasonEnabledBooleanFalse_shouldParseCorrectly() {
+        // Given - denyReasonEnabled as boolean false
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{\"denyReasonEnabled\":false}"),
+            uri = "mmfa:request:extras",
+            transactionId = "test-id"
+        )
+
+        // When
+        val jsonString = attribute.values.first()
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(jsonString).jsonObject
+
+        // Then
+        assertNotNull(jsonElement["denyReasonEnabled"])
+        assertEquals("false", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun attributeInfo_withDenyReasonEnabledStringFalse_shouldParseCorrectly() {
+        // Given - denyReasonEnabled as string "false"
+        val attribute = TransactionResult.AttributeInfo(
+            dataType = "String",
+            values = listOf("{\"denyReasonEnabled\":\"false\"}"),
+            uri = "mmfa:request:extras",
+            transactionId = "test-id"
+        )
+
+        // When
+        val jsonString = attribute.values.first()
+        val json = Json { ignoreUnknownKeys = true }
+        val jsonElement = json.parseToJsonElement(jsonString).jsonObject
+
+        // Then
+        assertNotNull(jsonElement["denyReasonEnabled"])
+        assertEquals("false", jsonElement["denyReasonEnabled"]?.jsonPrimitive?.content)
+    }
+    }
 }
 
 

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorService.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseAuthenticatorService.kt
@@ -812,7 +812,10 @@ class OnPremiseAuthenticatorService(
                 ) {
                     try {
                         val jsonString = attributeInfo.values.first()
-                        val jsonElement = Json.parseToJsonElement(jsonString).jsonObject
+                        // Handle malformed JSON with single quotes by replacing them with double quotes
+                        // This is a workaround for servers that send invalid JSON format
+                        val normalizedJsonString = jsonString.replace('\'', '"')
+                        val jsonElement = Json.parseToJsonElement(normalizedJsonString).jsonObject
 
                         // Extract and handle correlationEnabled (can be Boolean or String)
                         var isCorrelationEnabled = false

--- a/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt
+++ b/sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt
@@ -4,6 +4,7 @@
 
 package com.ibm.security.verifysdk.mfa.api
 
+import android.net.Uri
 import androidx.biometric.BiometricPrompt
 import com.ibm.security.verifysdk.authentication.api.OAuthProvider
 import com.ibm.security.verifysdk.authentication.model.TokenInfo
@@ -55,6 +56,7 @@ import kotlinx.serialization.json.put
 import org.slf4j.LoggerFactory
 import java.net.URL
 import java.util.UUID
+import androidx.core.net.toUri
 
 /**
  * Registration provider for IBM Verify Access (on-premise) multifactor authentication.
@@ -463,12 +465,38 @@ class OnPremiseRegistrationProvider(data: String) :
                 else -> algorithm.uppercase()
             }
 
-            // Construct complete TOTP URI with all parameters
-            val completeUri = if (baseUri.contains("?")) {
-                "$baseUri&digits=$digits&period=$period&algorithm=$algorithmParam"
-            } else {
-                "$baseUri?digits=$digits&period=$period&algorithm=$algorithmParam"
-            }
+            // Parse the base URI to check for existing parameters
+            val uri = baseUri.toUri()
+            val existingDigits = uri.getQueryParameter("digits")
+            val existingPeriod = uri.getQueryParameter("period")
+            val existingAlgorithm = uri.getQueryParameter("algorithm")
+
+            // Build URI with parameters, only adding if they don't already exist
+            val completeUri = buildString {
+                append(baseUri)
+                
+                // Add separator if needed
+                if (!baseUri.contains("?")) {
+                    append("?")
+                } else if (!baseUri.endsWith("&") && !baseUri.endsWith("?")) {
+                    append("&")
+                }
+                
+                val params = mutableListOf<String>()
+                
+                // Only add parameters if they don't already exist in the URI
+                if (existingDigits == null) {
+                    params.add("digits=$digits")
+                }
+                if (existingPeriod == null) {
+                    params.add("period=$period")
+                }
+                if (existingAlgorithm == null) {
+                    params.add("algorithm=$algorithmParam")
+                }
+                
+                append(params.joinToString("&"))
+            }.trimEnd('?', '&')  // Clean up trailing separators if no params were added
 
             // Use OTPAuthenticator.fromQRScan to parse the complete otpauth:// URI
             val otpAuthenticator = OTPAuthenticator.fromQRScan(completeUri)


### PR DESCRIPTION
## What does it do

This PR introduces custom User-Agent support, improving compatibility with legacy on-premise deployments, and significantly expands test coverage.

### New Features
- **Custom User-Agent Support**: Applications can now set a custom User-Agent header via `NetworkHelper.customUserAgent` that will be included in all SDK HTTP requests. This enables better application identification in server logs, analytics, and debugging scenarios.

### Bug Fixes
- **Malformed JSON Handling**: Added automatic normalization of single quotes to double quotes in transaction attribute JSON, improving compatibility with legacy IBM Verify Access deployments that return non-standard JSON format.
- **TOTP URI Parameter Duplication**: Fixed issue where `digits`, `period`, and `algorithm` parameters were being duplicated in TOTP URIs, ensuring OTP authenticators are created with correct configuration.


## Motivation and context

### Custom User-Agent Support
Many enterprise applications require the ability to identify themselves in server logs and analytics. The lack of custom User-Agent support made it difficult for developers to:
- Track SDK usage across different app versions
- Debug API issues with specific client configurations
- Meet compliance requirements for User-Agent reporting
- Differentiate between multiple applications using the same backend

This feature addresses these needs by providing a simple, thread-safe property that automatically applies to all HTTP clients (both secure and insecure).

### Legacy Server Compatibility
Some on-premise IBM Verify Access deployments (particularly older versions) return transaction attributes with JSON strings using single quotes instead of double quotes, which violates the JSON specification. This caused parsing failures and prevented transaction processing in these environments. The automatic normalization ensures backward compatibility without requiring server upgrades.

### TOTP URI Correctness
Server responses sometimes include TOTP URIs with partial parameters already present. The previous implementation would blindly append additional parameters, creating malformed URIs with duplicates like `?digits=6&digits=8`. This fix ensures the SDK respects existing parameters and only adds missing ones, improving reliability across different server implementations.

This release maintains full backward compatibility while adding valuable new capabilities and improving robustness for edge cases encountered in production environments.

## Related Documentation
[Release Notes](https://github.com/ibm-verify/verify-sdk-android/pull/docs/releases/3.2.6.md)
[Previous Release (3.2.5)](https://github.com/ibm-verify/verify-sdk-android/pull/docs/releases/3.2.5.md)