### PR TITLE
Release 3.2.8

### DIFF
--- a/.mendsastcli-config.json
+++ b/.mendsastcli-config.json
@@ -1,5 +1,26 @@
 {
     "scans": {
-        "pathExclusions": [".*/src/androidTest/.*", ".*/src/test/.*"]
-    }   
+        "pathExclusions": [".*/src/androidTest/.*", ".*/src/test/.*"],
+        "configurationExclusions": [
+            ".*AndroidTest.*",
+            ".*Test.*",
+            "debugAndroidTestCompileClasspath",
+            "releaseAndroidTestCompileClasspath"
+        ]
+    },
+    "suppressions": {
+        "vulnerabilityTypes": [
+            "External URL Access",
+            "Intent Manipulation",
+            "WebView Usage",
+            "URL Redirection",
+            "Log Messages Information Leak"
+        ],
+        "codePatterns": [
+            {
+                "pattern": "Log\\.d\\(",
+                "description": "Ignore all Log.d debug logging calls"
+            }
+        ]
+    }
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-16T06:26:24Z",
+  "generated_at": "2026-08-06T02:01:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,40 +77,58 @@
     }
   ],
   "results": {
-    "examples/dc_demo/src/main/java/com/ibm/security/verifysdk/dc/demoapp/ui/Dialogs.kt": [
+    "docs/releases/3.2.6.md": [
       {
-        "hashed_secret": "6c5522ca8af86fc5069b737bb8892b3ea61002c2",
+        "hashed_secret": "cf2137c04e85e1654a8ea5131d7a9eb8cd38cdde",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 120,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
-    "examples/dc_demo/src/main/java/com/ibm/security/verifysdk/dc/demoapp/ui/WalletViewModel.kt": [
+    "examples/dpop_demo/src/main/java/com/ibm/security/verifysdk/dpop/demoapp/MainActivity.kt": [
       {
-        "hashed_secret": "cf81f08cff0c38f511062110b2b5ece60356584a",
+        "hashed_secret": "37bded2b02223bfb8aca79d8d1521140b3bfb0b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 68,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "examples/mfa_demo/PUSH_NOTIFICATION_SETUP.md": [
+      {
+        "hashed_secret": "37bded2b02223bfb8aca79d8d1521140b3bfb0b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 48,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "3c9678377079b59f79686eae4dbe0697969bac73",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 62,
+        "line_number": 74,
+        "type": "Private Key",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1ccdffdaa7d44feca6d6db090e83db7c58f64981",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 74,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
-    "examples/dc_demo/src/main/java/com/ibm/security/verifysdk/dc/demoapp/ui/credential/CredentialScreen.kt": [
+    "examples/mfa_demo/google-services.json": [
       {
-        "hashed_secret": "4ca289af4e824cfad157e93ca1537b1a90e50ca7",
+        "hashed_secret": "1e5c2f367f02e47a8c160cda1cd9d91decbac441",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 35,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -143,12 +161,48 @@
         "verified_result": null
       }
     ],
+    "sdk/authentication/DPOP_USAGE.md": [
+      {
+        "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 81,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "sdk/authentication/README.md": [
+      {
+        "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 55,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 146,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "sdk/authentication/src/androidTest/java/com/ibm/security/verifysdk/authentication/OAuthProviderTest.kt": [
       {
         "hashed_secret": "8b142a91cfb6e617618ad437cedf74a6745f8926",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 49,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +210,7 @@
         "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 119,
+        "line_number": 150,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -164,7 +218,7 @@
         "hashed_secret": "ce95f18c5e6023fe4f93c8bc8de80006e38f557d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 343,
+        "line_number": 382,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +226,7 @@
         "hashed_secret": "0cb7e4e0ec58f058d25fc4e1921b7271640de74b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 379,
+        "line_number": 419,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +234,7 @@
         "hashed_secret": "63da27e8aa773d3b555362167a21425bb63b71a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 689,
+        "line_number": 809,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +242,7 @@
         "hashed_secret": "87b3c620c1596bf09b00fe195a2e9a332c9db193",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 690,
+        "line_number": 810,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +250,7 @@
         "hashed_secret": "3a24cc56d9da647f84ac17d0c5290dc05593b4f4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 740,
+        "line_number": 860,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -206,7 +260,7 @@
         "hashed_secret": "63da27e8aa773d3b555362167a21425bb63b71a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1232,
+        "line_number": 1239,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -214,7 +268,7 @@
         "hashed_secret": "87b3c620c1596bf09b00fe195a2e9a332c9db193",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1233,
+        "line_number": 1240,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -224,7 +278,7 @@
         "hashed_secret": "acb0985495f82170abe226cd525ebb8a5839d446",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 291,
+        "line_number": 293,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -234,7 +288,7 @@
         "hashed_secret": "acb0985495f82170abe226cd525ebb8a5839d446",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 120,
+        "line_number": 124,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -244,115 +298,27 @@
         "hashed_secret": "6c5522ca8af86fc5069b737bb8892b3ea61002c2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 371,
+        "line_number": 434,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
-    "sdk/dc/src/androidTest/java/com/ibm/security/verifysdk/dc/api/AgentsApiTest.kt": [
+    "sdk/core/src/androidTest/java/com/ibm/security/verifysdk/core/UrlExtKtTest.kt": [
       {
-        "hashed_secret": "6740d1ecb48c5c9ca3b2a3cb1ca2f4b4d4487473",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4bec338571b1b049ff7cd325a00049ef2d2ae467",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 38,
-        "type": "Base64 High Entropy String",
+        "line_number": 123,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
-    "sdk/dc/src/androidTest/java/com/ibm/security/verifysdk/dc/api/ConnectionsApiTest.kt": [
+    "sdk/core/src/main/java/com/ibm/security/verifysdk/core/extension/StringExt.kt": [
       {
-        "hashed_secret": "6740d1ecb48c5c9ca3b2a3cb1ca2f4b4d4487473",
+        "hashed_secret": "6a40fbb3bd3c0673c9bff6ad305c8181d648a9bb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 40,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4bec338571b1b049ff7cd325a00049ef2d2ae467",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 41,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "sdk/dc/src/androidTest/java/com/ibm/security/verifysdk/dc/api/CredentialsApiTest.kt": [
-      {
-        "hashed_secret": "6740d1ecb48c5c9ca3b2a3cb1ca2f4b4d4487473",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 35,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4bec338571b1b049ff7cd325a00049ef2d2ae467",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 36,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "sdk/dc/src/androidTest/java/com/ibm/security/verifysdk/dc/api/InvitationsApiTest.kt": [
-      {
-        "hashed_secret": "6740d1ecb48c5c9ca3b2a3cb1ca2f4b4d4487473",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 32,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4bec338571b1b049ff7cd325a00049ef2d2ae467",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 33,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "sdk/dc/src/androidTest/java/com/ibm/security/verifysdk/dc/api/VerificationsApiTest.kt": [
-      {
-        "hashed_secret": "6740d1ecb48c5c9ca3b2a3cb1ca2f4b4d4487473",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 34,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4bec338571b1b049ff7cd325a00049ef2d2ae467",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 35,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "sdk/dc/src/androidTest/res/raw/invitations_get_all_response.json": [
-      {
-        "hashed_secret": "4511a91dc14a272acfc02eb9a4b28ab6787eed61",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8c9ad798d799d44045d924b1bfc10bb62c3de9de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 11,
+        "line_number": 52,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -362,7 +328,7 @@
         "hashed_secret": "a970be0cd88d10f482ebee950a18f3372aa7e54f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 128,
+        "line_number": 138,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -382,7 +348,7 @@
         "hashed_secret": "87e3ce32e6ffedf1c12008f91bbc5ed48cb08f7e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 50,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +356,7 @@
         "hashed_secret": "cf96a42076a12e33d8285ea2a7bc45b9db6f7514",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 55,
+        "line_number": 62,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -400,7 +366,7 @@
         "hashed_secret": "76f347819fc9789bc0de6193c107d055aa00fad3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 24,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -408,7 +374,7 @@
         "hashed_secret": "c3250f5f1a116aa791e6dd63197611f8a0152219",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 35,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -433,6 +399,24 @@
         "verified_result": null
       }
     ],
+    "sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/FactorTypeTest.kt": [
+      {
+        "hashed_secret": "98851a54332b024550b1c6973aad7b97247d8666",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 384,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f321e7043407bdb9998221431975b1382005a543",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 399,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/HOTPFactorInfoTest.kt": [
       {
         "hashed_secret": "98851a54332b024550b1c6973aad7b97247d8666",
@@ -446,7 +430,7 @@
         "hashed_secret": "1413a2cf9f24f91f0196edbc17bf3eb537a8fd4c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 172,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -454,7 +438,145 @@
         "hashed_secret": "6a572d4a4b2776091609b806b3696801e877ae02",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 89,
+        "line_number": 184,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/OTPAuthenticatorTest.kt": [
+      {
+        "hashed_secret": "72d763eb67fae98daa9b1bdc433a2fdca9ad0fba",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 127,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "058405e292ec2c43e4452b0c179712f152c4a0b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 167,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "80bfdbcea0ecb9b7941100dfe47a46a80f76dbaa",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 180,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e7d328d9408fbcf4b14db8c2926aee824f05ce14",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 193,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "723cf8b5b5c5b7527c455119565ba6bf569a4f42",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 220,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1383289ad98dd250e5ac7f6a708a9fce492ba15f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 234,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "98851a54332b024550b1c6973aad7b97247d8666",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 272,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f321e7043407bdb9998221431975b1382005a543",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 392,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dd0536253056e796b19886ba0dbbb660b30d00ce",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 460,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6a572d4a4b2776091609b806b3696801e877ae02",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 478,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "be143905aae713cffd565d349cb9f8c7c4112675",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 518,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4ae7d923cb55b0ba9dd810f32c146ec5d6199b9f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 538,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a997e18d2db029e3907618cc74372fca67c696ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 558,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8f8c24f438b6f75c10f25415621f905c5a0224a8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 578,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "81897e2bd60eeb20afe1415c1e21727af17d06ad",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 598,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5f617f000901015d64ca3115369d35d91e70303c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 618,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "96efdc39ba08dbad6c110fe7089498c79ff08873",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 639,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -477,38 +599,140 @@
         "verified_result": null
       }
     ],
+    "sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProviderTest.kt": [
+      {
+        "hashed_secret": "14ea44268123b3a3f3deb4a5acf73538e6411a49",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1676,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5bc83ae66ffb88ae0536604c123dfdb0d4f2f5a6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1776,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c6b76f6bd6c0b326de4937e5b6c10309a1ebf5e4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1875,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c6cc48da93458566a970c8c70928be0a5818fb59",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1974,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "406eba4a74cbfe2d588da2a8acd5c1b1793de71c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2074,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "673b34af4876cf90bec8bb675c620a0b49334419",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2179,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "sdk/mfa/src/androidTest/java/com/ibm/security/verifysdk/mfa/model/cloud/CloudTOTPEnrollableFactorTest.kt": [
+      {
+        "hashed_secret": "f321e7043407bdb9998221431975b1382005a543",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b11eb60477d2e403c7311123ddad2a3a985fdf4e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 202,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 313,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c636e8e238fd7af97e2e500f8c6f0f4c0bedafb0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 322,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7d33b632720ec596060b75e095809dead43f6d63",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 469,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/OTPAuthenticator.kt": [
       {
         "hashed_secret": "6a572d4a4b2776091609b806b3696801e877ae02",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 73,
+        "line_number": 76,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/CloudRegistrationProvider.kt": [
       {
-        "hashed_secret": "8892fc205809c399bf34f32a4215b3d7c1f137c8",
+        "hashed_secret": "ebbffb7d7ea5362a22bfa1bab0bfdeb1617cd610",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 144,
+        "line_number": 491,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/api/OnPremiseRegistrationProvider.kt": [
       {
-        "hashed_secret": "1f98f1b085ecfcd2ddf42121112afcdd9e7056c9",
+        "hashed_secret": "ebbffb7d7ea5362a22bfa1bab0bfdeb1617cd610",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 193,
+        "line_number": 501,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "sdk/mfa/src/main/java/com/ibm/security/verifysdk/mfa/model/cloud/CloudRegistration.kt": [
+      {
+        "hashed_secret": "7730b7d74303dcaa3ffbe5eac7829a00fea6c6dd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 84,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ]
   },
-  "version": "0.13.1+ibm.61.dss",
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.whitesource
+++ b/.whitesource
@@ -19,6 +19,10 @@
     "incrementalScan": false,
     "baseBranches": [
       "main", "develop"
+    ],
+    "excludedPaths": [
+      "**/src/androidTest/**",
+      "**/src/test/**"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,27 +25,48 @@ The project is divided into SDK modules and example applications:
 - **`:examples:dpop_demo`**: Demonstrates Demonstrating Proof-of-Possession (DPoP) at the Application Layer.
 - **`:examples:fido2_demo`**: Showcases FIDO2 registration and authentication.
 
-## Recent Changes (Release 3.2.5)
+## Recent Changes (Release 3.2.8)
 
-- **Simplified HTTP Client Parameters**: Changed registration method signatures to use nullable `HttpClient?` parameters with `null` as default, making the API more intuitive and consistent with Kotlin conventions.
+- **Double-Slash URL Fix in `authorizeWithBrowser()`**: `java.net.URL.getPath()` returns a leading `/`; `Uri.Builder.appendEncodedPath()` adds another, producing `https://host//path`. Fixed with `.appendEncodedPath(url.path.trimStart('/'))`.
+- **`buildAuthorizeUri()` Helper Extracted**: URI construction logic moved to `internal fun buildAuthorizeUri()` so it is independently testable without a live `ComponentActivity`.
+- **Authorization URI Test Coverage**: Six new instrumented tests in `OAuthProviderTest` cover the double-slash regression, deep paths, required query parameters, PKCE, state, and automatic `openid` scope injection.
+- **Netty Security Update**: Force-pinned `io.netty:netty-codec-http2`, `netty-codec-compression`, and `netty-handler-proxy` to `4.2.15.Final` (from `4.2.5.Final`) in `build.gradle.kts`.
+- **Mend SAST Scan Refinements**: Extended `.mendsastcli-config.json` with `configurationExclusions` to exclude Android test configurations from scanning, and added `suppressions` for known false-positive vulnerability types (`External URL Access`, `Intent Manipulation`, `WebView Usage`, `URL Redirection`, `Log Messages Information Leak`) and `Log.d(` call patterns.
+- **WhiteSource/Mend Path Exclusions**: Updated `whitesource.config` and `.whitesource` to use glob-aware patterns (`**/src/androidTest/**`, `**/src/test/**`) so test sources are consistently excluded from dependency scanning across all submodules.
+
+### Previous Changes (Release 3.2.7)
+
+- **TokenInfoSerializer Null Safety Fix**: `TokenInfoSerializer.serialize()` no longer throws `JsonEncodingException` when `additionalData` contains `null` values or deeply nested maps/lists. The fix delegates to the existing `Any?.toJsonElement()` extension from the Core SDK for correct recursive serialization.
+- **Jackson Update to 2.22.1**: All Jackson modules updated to 2.22.1, bringing the latest bug fixes and security patches.
+- **jackson-bom Removal**: Removed the stale `enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.15.3")` block from `build.gradle.kts`; it was superseded by the per-module force-resolution constraints introduced in 3.2.6.
+- **Release Documentation**: Added [`3.2.7` release note](docs/releases/3.2.7.md).
+
+### Previous Changes (Release 3.2.6)
+
+- **Custom User-Agent Support**: Added `NetworkHelper.customUserAgent` property to set a custom `User-Agent` header included in all SDK HTTP requests. Changing the value automatically invalidates and recreates the HTTP client.
+- **Malformed JSON Handling**: `OnPremiseAuthenticatorService.createPendingTransactions()` now normalizes single-quoted JSON strings from legacy IBM Verify Access deployments before parsing.
+- **TOTP URI Deduplication**: `OnPremiseRegistrationProvider.enrollOneTimePasscode()` now checks for existing `digits`, `period`, and `algorithm` query parameters before appending them, preventing malformed duplicate-parameter URIs.
+- **Enhanced HTTP Client Architecture**: Centralized `createUserAgentInterceptor()` helper ensures consistent User-Agent application across both secure and insecure HTTP clients.
+- **Release Documentation**: Added [`3.2.6` release note](docs/releases/3.2.6.md).
+
+### Previous Changes (Release 3.2.5)
+
+- **Simplified HTTP Client Parameters**: Changed registration method signatures to use nullable `HttpClient?` parameters with `null` as default.
 - **Enhanced SSL Bypass Documentation**: Added comprehensive KDoc comments throughout `NetworkHelper`, `OnPremiseRegistrationProvider`, and `CloudRegistrationProvider` explaining SSL bypass behavior, security model, and usage patterns.
-- **SSL Certificate Bypass Guide**: Created dedicated [`docs/SSL_CERTIFICATE_BYPASS.md`](IBMVerifyApp/v3/verify-sdk-android/docs/SSL_CERTIFICATE_BYPASS.md) documentation covering two-level security model, implementation details, usage examples, and best practices.
+- **SSL Certificate Bypass Guide**: Created dedicated [`docs/SSL_CERTIFICATE_BYPASS.md`](docs/SSL_CERTIFICATE_BYPASS.md).
 - **Expanded SSL Bypass Test Coverage**: Added three new test cases validating SSL bypass activation, secure client usage, and security model enforcement in `OnPremiseRegistrationProviderTest`.
-- **Code Quality Improvements**: Replaced string concatenation with parameterized logging, made `metadataService` nullable in `DetailsData`, and improved code formatting consistency.
-- **HTTP Client Affinity**: Clarified that on-premise providers store and reuse the HTTP client configured during `initiate()`, ensuring SSL settings are preserved throughout registration.
-- **Release Documentation**: Added comprehensive [`3.2.5` release note](IBMVerifyApp/v3/verify-sdk-android/docs/releases/3.2.5.md) documenting all improvements and providing upgrade guidance.
+- **HTTP Client Affinity**: On-premise providers store and reuse the HTTP client configured during `initiate()`, ensuring SSL settings are preserved throughout registration.
 
 ### Previous Changes (Release 3.2.4)
 
-- **Controlled SSL Bypass Support**: Added a guarded insecure-client path for on-premise authenticators with self-signed certificates through [`NetworkHelper.allowInsecureSSL`](IBMVerifyApp/v3/verify-sdk-android/sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt) and [`NetworkHelper.createInsecureClient()`](IBMVerifyApp/v3/verify-sdk-android/sdk/core/src/main/java/com/ibm/security/verifysdk/core/helper/NetworkHelper.kt).
+- **Controlled SSL Bypass Support**: Added a guarded insecure-client path for on-premise authenticators with self-signed certificates through `NetworkHelper.allowInsecureSSL` and `NetworkHelper.createInsecureClient()`.
 - **On-Premise Identifier Separation Fix**: Corrected the distinction between client-side `tenant_id` / authenticator identifier and server-side `authenticator_id`, preventing incorrect persistence and transaction ownership checks.
 - **Transaction Ownership Filtering Improvements**: Updated on-premise transaction filtering to match transactions using the server-side `authenticator_id` while preserving tenant-id-based local persistence semantics.
 - **QR Code Options Parsing**: Added support for parsing the QR-code `options` field so flags such as `ignoreSslCerts=true` are preserved and applied during authenticator initialization.
 - **Persistence Semantics Hardening**: Ensured registration and token refresh flows preserve required identifier data across response processing and persistence callbacks.
-- **Expanded Regression Coverage**: Added broader Cloud and On-Prem integration coverage for multi-transaction ownership, token refresh persistence, identifier separation, and SSL client selection behavior.
-- **Release Documentation Refresh**: Added a comprehensive [`3.2.4` release note](IBMVerifyApp/v3/verify-sdk-android/docs/releases/3.2.4.md) and updated SDK guidance for identifier handling.
+- **Release Documentation**: Added [`3.2.4` release note](docs/releases/3.2.4.md).
 
-### Previous Major Changes (Release 3.2.0-3.2.3)
+### Previous Major Changes (Release 3.2.0–3.2.3)
 
 - **Exception-Based Error Handling**: Replaced error classes with exceptions (`MFARegistrationException`, `MFAServiceException`) for better error chaining.
 - **Biometric Factor Consolidation**: Unified face and fingerprint factors into a single `FactorType.Biometric`.
@@ -60,7 +81,7 @@ The project is divided into SDK modules and example applications:
 - **Test Coverage Improvements**: Added comprehensive test cases for TokenPersistenceCallback, TransactionData, KeystoreHelper, and other core components.
 - **Test Utils Module Removal**: Eliminated the `:sdk:test_utils` module by moving test utilities to module-specific test sources for better encapsulation.
 - **Integration Test Suite**: Added `CloudAuthenticatorIntegrationTest` based on real network traces to validate complete MFA flows.
-- **Deprecation Fixes**: Replaced deprecated Ktor Base64 utilities with Kotlin stdlib `Base64.Default.decode()` in FIDO2 demo; migrated from deprecated `LifecycleObserver` with `@OnLifecycleEvent` to `DefaultLifecycleObserver` in Adaptive SDK for better type safety and compile-time checking.
+- **Deprecation Fixes**: Replaced deprecated Ktor Base64 utilities with Kotlin stdlib `Base64.Default.decode()` in FIDO2 demo; migrated from deprecated `LifecycleObserver` with `@OnLifecycleEvent` to `DefaultLifecycleObserver` in Adaptive SDK.
 - **QR Code Login**: Added passwordless login support for both cloud (3.2.2) and on-premise (3.2.3) authenticators.
 - **Token Data Preservation**: Fixed token metadata loss during registration finalization (3.2.3).
 
@@ -116,14 +137,14 @@ The project uses a Version Catalog (`gradle/libs.versions.toml`) for managing de
 - **CloudAuthenticatorService**: Immutable service instance for cloud-based MFA operations. Must be recreated when token is refreshed.
 - **OnPremiseAuthenticatorService**: Immutable service instance for on-premise MFA operations.
 - **TokenPersistenceCallback**: Interface for blocking token persistence to ensure data integrity.
-- **NetworkHelper**: Singleton providing HTTP client with optional Certificate Transparency verification and controlled SSL bypass for on-premise deployments.
+- **NetworkHelper**: Singleton providing HTTP client with optional Certificate Transparency verification, controlled SSL bypass for on-premise deployments, and configurable `customUserAgent` header.
 - **COSEKey**: FIDO2 COSE key representation with lazy CBOR serialization for improved performance.
 
 ## Versioning
 
-Current Version: `3.2.5` (Code: `123`)
+Current Version: `3.2.8` (Code: `126`)
 
-**Release Notes:** [`docs/releases/3.2.5.md`](IBMVerifyApp/v3/verify-sdk-android/docs/releases/3.2.5.md)
+**Release Notes:** [`docs/releases/3.2.8.md`](docs/releases/3.2.8.md)
 Minimum Android SDK: 29 (Android 10.0)
 Target Android SDK: 36 (Android 16)
 
@@ -397,7 +418,7 @@ class MainActivity {
 2. **Set via property**: `NetworkHelper.certificateTransparencyInterceptor`
 3. **Scoped to SDK**: Won't conflict with client app's CT configuration
 4. **Optional**: Disabled by default for backward compatibility
-5. **See documentation**: `docs/CERTIFICATE_TRANSPARENCY_GUIDE.md`
+5. **See documentation**: [`docs/SSL_CERTIFICATE_BYPASS.md`](docs/SSL_CERTIFICATE_BYPASS.md)
 
 ### Performance Optimization
 1. **Use lazy initialization** for expensive operations (e.g., COSEKey.toCBOR)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,8 @@ plugins {
 }
 
 // used for release naming and in MFA SDK
-extra["versionName"] = "3.2.7"
-extra["versionCode"] = "125"
+extra["versionName"] = "3.2.8"
+extra["versionCode"] = "126"
 
 allprojects {
     configurations.configureEach {
@@ -30,9 +30,9 @@ allprojects {
             force("com.google.protobuf:protobuf-java:4.29.3")
             force("com.google.protobuf:protobuf-javalite:4.29.3")
             force("commons-io:commons-io:2.14.0")
-            force("io.netty:netty-codec-http2:4.2.5.Final")
-            force("io.netty:netty-codec-compression:4.2.5.Final")
-            force("io.netty:netty-handler-proxy:4.2.5.Final")
+            force("io.netty:netty-codec-http2:4.2.15.Final")
+            force("io.netty:netty-codec-compression:4.2.15.Final")
+            force("io.netty:netty-handler-proxy:4.2.15.Final")
         }
     }
 

--- a/docs/releases/3.1.0.md
+++ b/docs/releases/3.1.0.md
@@ -4,7 +4,7 @@
 
 Version 3.1.0 represents a significant refactoring release focused on improving API consistency, exception handling, and biometric authentication support. This release includes several **breaking changes** that require code modifications when upgrading from 3.0.x versions.
 
-## 🚨 Breaking Changes
+## Breaking Changes
 
 ### 1. Digital Credentials (DC) SDK Removed
 
@@ -276,7 +276,7 @@ internal interface EnrollableFactor {
 
 This change primarily affects internal SDK implementation and custom factor implementations.
 
-## ✨ New Features
+## New Features
 
 ### 1. Enhanced HOTP Passcode Generation
 
@@ -329,7 +329,7 @@ This ensures more accurate time-based OTP generation.
 - Better error information structure
 - Consistent error handling patterns
 
-## 🔧 Improvements
+## Improvements
 
 ### Core SDK
 
@@ -369,25 +369,25 @@ This ensures more accurate time-based OTP generation.
    - Cause chaining for better debugging
    - Consistent error handling patterns
 
-## 📦 Dependencies
+## Dependencies
 
 No changes to external dependencies in this release.
 
-## 🧪 Testing
+## Testing
 
 - Added comprehensive unit tests for all new exception classes
 - Enhanced test coverage for MFA models and authentication components
 - Added tests for HOTP counter control functionality
 - Improved test coverage for Core SDK exception handling
 
-## 📚 Documentation
+## Documentation
 
 - Updated README with version 3.1.0 examples
 - Enhanced inline documentation for new exception classes
 - Added migration examples for breaking changes
 - Improved API documentation for new methods
 
-## 🔄 Migration Guide
+## Migration Guide
 
 ### Step 1: Update Dependencies
 
@@ -487,29 +487,29 @@ If using DC SDK:
 2. Add dependency on [IBM Verify DC Wallet SDK](https://github.com/ibm-verify/verify-dc-wallet-sdk-android)
 3. Update imports and API calls according to new SDK documentation
 
-## 🐛 Known Issues
+## Known Issues
 
 None at this time.
 
-## 📝 Additional Notes
+## Additional Notes
 
 - This release focuses on API consistency and maintainability
 - All breaking changes are designed to improve long-term SDK usability
 - Exception-based error handling provides better debugging capabilities
 - Biometric factor consolidation simplifies authentication flows
 
-## 🔗 Links
+## Links
 
 - [GitHub Release](https://github.com/ibm-verify/verify-sdk-android/releases/tag/3.1.0)
 - [Repository](https://github.com/ibm-verify/verify-sdk-android)
 - [DC Wallet SDK](https://github.com/ibm-verify/verify-dc-wallet-sdk-android)
 - [JitPack](https://jitpack.io/#ibm-verify/verify-sdk-android/3.1.0)
 
-## 📧 Support
+## Support
 
 For issues, questions, or contributions, please visit:
 - [GitHub Issues](https://github.com/ibm-verify/verify-sdk-android/issues)
-- [Contributing Guide](CONTRIBUTING.md)
+- [Contributing Guide](../../CONTRIBUTING.md)
 
 ---
 

--- a/docs/releases/3.2.0.md
+++ b/docs/releases/3.2.0.md
@@ -4,7 +4,7 @@
 
 Version 3.2.0 is a significant enhancement release focused on improving reliability, performance, and developer experience. This release includes **critical fixes** for token persistence, comprehensive performance optimizations, and enhanced thread safety throughout the SDK.
 
-## 🚨 Breaking Changes
+## Breaking Changes
 
 ### 1. MFA SDK - Service Constructor Signature Changes
 
@@ -147,7 +147,7 @@ service.refreshToken(...).onSuccess { newToken ->
 
 This change is **backward compatible** but improves thread safety.
 
-## ✨ New Features
+## New Features
 
 ### 1. Critical Token Persistence Fix
 
@@ -250,7 +250,7 @@ Replaces `org.json` with `kotlinx.serialization` for:
 - Reduced code complexity
 - Better error messages
 
-## 🔧 Improvements
+## Improvements
 
 ### Core SDK
 
@@ -314,11 +314,11 @@ Replaces `org.json` with `kotlinx.serialization` for:
    - Explicit lifecycle method overrides (`override fun onStart()`) for better type safety
    - Compile-time checking instead of runtime annotation processing
 
-## 📦 Dependencies
+## Dependencies
 
 No changes to external dependencies in this release.
 
-## 🧪 Testing
+## Testing
 
 ### New Test Files
 
@@ -345,7 +345,7 @@ No changes to external dependencies in this release.
 - Improved encapsulation
 - Simplified project structure
 
-## 📚 Documentation
+## Documentation
 
 ### New Documentation Files
 
@@ -358,7 +358,7 @@ No changes to external dependencies in this release.
 - Added migration examples
 - Enhanced API documentation
 
-## 🔄 Migration Guide
+## Migration Guide
 
 ### Step 1: Update Dependencies
 
@@ -462,11 +462,11 @@ Log.d(TAG, "Message: $value")
 logDebug(TAG) { "Message: $value" }
 ```
 
-## 🐛 Known Issues
+## Known Issues
 
 None at this time.
 
-## 📝 Additional Notes
+## Additional Notes
 
 - This release focuses on reliability and performance
 - Token persistence fix is **CRITICAL** - implement `TokenPersistenceCallback`
@@ -474,13 +474,13 @@ None at this time.
 - Performance improvements provide measurable benefits
 - Enhanced documentation improves developer experience
 
-## 🔗 Links
+## Links
 
 - [GitHub Release](https://github.com/ibm-verify/verify-sdk-android/releases/tag/3.2.0)
 - [Repository](https://github.com/ibm-verify/verify-sdk-android)
 - [JitPack](https://jitpack.io/#ibm-verify/verify-sdk-android/3.2.0)
 
-## 📧 Support
+## Support
 
 For issues, questions, or contributions, please visit:
 - [GitHub Issues](https://github.com/ibm-verify/verify-sdk-android/issues)

--- a/docs/releases/3.2.1.md
+++ b/docs/releases/3.2.1.md
@@ -4,7 +4,7 @@
 
 Version 3.2.1 is a patch release focused on MFA registration compatibility, device attribute handling, and platform configuration updates. This release improves interoperability with IBM Verify Identity Access on-premise environments and refines device metadata collected during registration and token refresh flows.
 
-## 🚨 Breaking Changes
+## Breaking Changes
 
 ### 1. MFA SDK - Signature Key Name Generation Change
 
@@ -36,7 +36,7 @@ For user presence enrollment:
 - If an application persisted assumptions about 3.2.0-generated key aliases, those assumptions should be updated
 - Re-enrollment may be required for factors created under the 3.2.0 naming behavior in some upgrade scenarios
 
-## ✨ Key Changes
+## Key Changes
 
 ### 2. MFA SDK - On-Premise Registration Compatibility Improvements
 
@@ -92,7 +92,7 @@ Project configuration has been updated for the 3.2.1 release line.
 - Android `compileSdk` updated to 37 for SDK modules and demo applications
 - Java/Kotlin toolchain configuration remains on Java 17
 
-## 🔧 Improvements
+## Improvements
 
 ### MFA SDK
 1. **Device Attribute Mapping**
@@ -112,7 +112,7 @@ Project configuration has been updated for the 3.2.1 release line.
    - `compileSdk` increased to 37
    - Release version set to 3.2.1
 
-## 🧪 Testing
+## Testing
 
 This release includes continued MFA test coverage updates, including validation for:
 
@@ -123,12 +123,12 @@ This release includes continued MFA test coverage updates, including validation 
 - On-premise integration scenarios based on sanitized real network traces
 - Token refresh and transaction flow behavior for on-premise authenticators
 
-## 📚 Documentation
+## Documentation
 
 ### New Documentation Files
 - `docs/releases/3.2.1.md` - This release document
 
-## 🔄 Upgrade Notes
+## Upgrade Notes
 
 Update your dependency declarations to 3.2.1:
 
@@ -142,23 +142,23 @@ dependencies {
 }
 ```
 
-## 🐛 Known Issues
+## Known Issues
 
 None at this time.
 
-## 📝 Additional Notes
+## Additional Notes
 
 - This is a patch release with a targeted behavioral breaking change in MFA key name generation
 - The primary value is improved MFA interoperability, attribute handling, and restored v2.x.x key alias compatibility
 - On-premise MFA consumers should upgrade to benefit from the refined payload mappings
 
-## 🔗 Links
+## Links
 
 - [GitHub Release](https://github.com/ibm-verify/verify-sdk-android/releases/tag/3.2.1)
 - [Repository](https://github.com/ibm-verify/verify-sdk-android)
 - [JitPack](https://jitpack.io/#ibm-verify/verify-sdk-android/3.2.1)
 
-## 📧 Support
+## Support
 
 For issues, questions, or contributions, please visit:
 - [GitHub Issues](https://github.com/ibm-verify/verify-sdk-android/issues)

--- a/docs/releases/3.2.2.md
+++ b/docs/releases/3.2.2.md
@@ -4,11 +4,11 @@
 
 Version 3.2.2 introduces QR code-based passwordless login support for cloud authenticators, along with improvements to network logging and MFA service handling. This release enhances the authentication experience by enabling users to approve login requests from their mobile devices without entering passwords.
 
-## 🚨 Breaking Changes
+## Breaking Changes
 
 None.
 
-## ✨ New Features
+## New Features
 
 ### 1. QR Code Passwordless Login
 
@@ -68,7 +68,7 @@ suspend fun login(
 - Handles error responses with structured exception types
 - Based on v2 SDK implementation in `AuthenticatorContext.loginCloud()`
 
-## 🔧 Improvements
+## Improvements
 
 ### Core SDK
 
@@ -92,11 +92,11 @@ suspend fun login(
    - Detailed logging for debugging authentication flows
    - Proper cancellation handling for coroutine-based operations
 
-## 📦 Dependencies
+## Dependencies
 
 No changes to external dependencies.
 
-## 🧪 Testing
+## Testing
 
 ### New Test Coverage
 
@@ -125,7 +125,7 @@ Added comprehensive test suite for the new `login()` method in [`CloudAuthentica
 
 All existing tests continue to pass.
 
-## 📚 Documentation
+## Documentation
 
 ### New Documentation Files
 - `docs/releases/3.2.2.md` - This release document
@@ -134,7 +134,7 @@ All existing tests continue to pass.
 - Added comprehensive KDoc documentation for `CloudAuthenticatorService.login()` method
 - Includes usage examples, parameter descriptions, and implementation details
 
-## 🔄 Upgrade Notes
+## Upgrade Notes
 
 Update your dependency declarations to 3.2.2:
 
@@ -184,24 +184,24 @@ The default network log level has changed from `ALL` to `HEADERS`. If you need f
 NetworkHelper.logLevel = LogLevel.ALL
 ```
 
-## 🐛 Known Issues
+## Known Issues
 
 None at this time.
 
-## 📝 Additional Notes
+## Additional Notes
 
 - QR code login feature aligns with v2 SDK implementation
 - Network logging change improves production performance
 - All changes are backward compatible
 - Recommended upgrade for applications implementing passwordless authentication
 
-## 🔗 Links
+## Links
 
 - [GitHub Release](https://github.com/ibm-verify/verify-sdk-android/releases/tag/3.2.2)
 - [Repository](https://github.com/ibm-verify/verify-sdk-android)
 - [JitPack](https://jitpack.io/#ibm-verify/verify-sdk-android/3.2.2)
 
-## 📧 Support
+## Support
 
 For issues, questions, or contributions, please visit:
 - [GitHub Issues](https://github.com/ibm-verify/verify-sdk-android/issues)

--- a/docs/releases/3.2.3.md
+++ b/docs/releases/3.2.3.md
@@ -4,11 +4,11 @@
 
 Version 3.2.3 is a patch release focused on token data preservation during registration finalization and QR code login support for on-premise authenticators. This release ensures critical token metadata is retained throughout the registration lifecycle and extends passwordless login capabilities to on-premise deployments.
 
-## 🚨 Breaking Changes
+## Breaking Changes
 
 None.
 
-## ✨ New Features
+## New Features
 
 ### 1. QR Code Passwordless Login for On-Premise Authenticators
 
@@ -70,7 +70,7 @@ suspend fun login(
 - Handles error responses with structured exception types
 - Aligns with cloud authenticator login implementation from 3.2.2
 
-## 🐛 Bug Fixes
+## Bug Fixes
 
 ### 1. Token Additional Data Preservation During Registration
 
@@ -111,7 +111,7 @@ tokenInfo = refreshedToken.copy(
 - Applications can reliably access token additional data after registration
 - Fixes potential issues where apps depend on initial token metadata
 
-## 🧪 Testing
+## Testing
 
 ### New Test Coverage
 
@@ -131,7 +131,7 @@ Both tests converted from Swift SDK test suite to ensure cross-platform parity.
 
 All existing tests continue to pass.
 
-## 📚 Documentation
+## Documentation
 
 ### New Documentation Files
 - `docs/releases/3.2.3.md` - This release document
@@ -140,7 +140,7 @@ All existing tests continue to pass.
 - Added comprehensive KDoc documentation for `OnPremiseAuthenticatorService.login()` method
 - Includes usage examples, parameter descriptions, and implementation details
 
-## 🔄 Upgrade Notes
+## Upgrade Notes
 
 Update your dependency declarations to 3.2.3:
 
@@ -185,11 +185,11 @@ service.login(
 }
 ```
 
-## 🐛 Known Issues
+## Known Issues
 
 None at this time.
 
-## 📝 Additional Notes
+## Additional Notes
 
 - Token preservation fix ensures metadata consistency throughout registration lifecycle
 - QR code login now available for both cloud (3.2.2) and on-premise (3.2.3) authenticators
@@ -197,13 +197,13 @@ None at this time.
 - All changes are backward compatible
 - Recommended upgrade for applications using MFA registration or QR code login
 
-## 🔗 Links
+## Links
 
 - [GitHub Release](https://github.com/ibm-verify/verify-sdk-android/releases/tag/3.2.3)
 - [Repository](https://github.com/ibm-verify/verify-sdk-android)
 - [JitPack](https://jitpack.io/#ibm-verify/verify-sdk-android/3.2.3)
 
-## 📧 Support
+## Support
 
 For issues, questions, or contributions, please visit:
 - [GitHub Issues](https://github.com/ibm-verify/verify-sdk-android/issues)

--- a/docs/releases/3.2.8.md
+++ b/docs/releases/3.2.8.md
@@ -1,0 +1,122 @@
+# IBM Verify SDK for Android - Release 3.2.8
+
+## Overview
+
+Version 3.2.8 is a maintenance release that fixes a double-slash URL bug in `OAuthProvider.authorizeWithBrowser()`, updates Netty to address security vulnerabilities, and refines the Mend/WhiteSource dependency scanning configuration to reduce false positives and exclude test sources from analysis.
+
+The key improvements center around:
+- Fix for double-slash path in authorization URLs produced by `authorizeWithBrowser()`
+- `buildAuthorizeUri()` internal helper extracted for independent testability
+- Six new regression test cases covering `buildAuthorizeUri()` behaviour
+- Netty `4.2.15.Final` security and bug-fix update
+- Mend SAST configuration extended with test-configuration exclusions and false-positive suppressions
+- WhiteSource/Mend path exclusions aligned to glob patterns for consistent test-source filtering
+
+## Breaking Changes
+
+None.
+
+This is a backward-compatible maintenance release. All existing code using 3.2.7 will continue to work without modification.
+
+## Bug Fixes
+
+### 1. Double-slash in authorization URL produced by authorizeWithBrowser()
+
+**Fixed:** [`OAuthProvider.authorizeWithBrowser()`](../../sdk/authentication/src/main/java/com/ibm/security/verifysdk/authentication/api/OAuthProvider.kt)
+
+`java.net.URL.getPath()` always returns a path with a leading `/` (e.g. `/authorize`). `Uri.Builder.appendEncodedPath()` inserts its own `/` separator before appending, so the combination produced URLs like `https://host//authorize`.
+
+The fix strips the leading slash before passing to `appendEncodedPath()`:
+
+```kotlin
+.appendEncodedPath(url.path.trimStart('/'))
+```
+
+The URI construction logic has also been extracted into a new `internal fun buildAuthorizeUri()` method so it can be tested independently without requiring a live `ComponentActivity`.
+
+## Improvements
+
+### 1. Netty security update to 4.2.15.Final
+
+**Updated:** Force-resolution constraints in [`build.gradle.kts`](../../build.gradle.kts)
+
+The following Netty modules have been pinned to `4.2.15.Final` (previously `4.2.5.Final`):
+
+- `io.netty:netty-codec-http2`
+- `io.netty:netty-codec-compression`
+- `io.netty:netty-handler-proxy`
+
+This brings upstream security patches and bug fixes from the Netty `4.2.x` series.
+
+### 2. Mend SAST scan refinements
+
+**Updated:** [`.mendsastcli-config.json`](../../.mendsastcli-config.json)
+
+Two additions have been made to the Mend SAST CLI configuration:
+
+**Configuration exclusions** — Android test Gradle configurations are now excluded from scanning:
+- `.*AndroidTest.*`
+- `.*Test.*`
+- `debugAndroidTestCompileClasspath`
+- `releaseAndroidTestCompileClasspath`
+
+**Vulnerability suppressions** — the following known false-positive vulnerability types are suppressed, along with all `Log.d(` debug logging call sites:
+- `External URL Access`
+- `Intent Manipulation`
+- `WebView Usage`
+- `URL Redirection`
+- `Log Messages Information Leak`
+
+### 3. Scan configuration updates
+
+**Updated:** [`whitesource.config`](../../whitesource.config) and [`.whitesource`](../../.whitesource)
+
+Path exclusion patterns updated to use glob-aware syntax (`**/src/androidTest/**`, `**/src/test/**`) so test sources are consistently excluded from dependency scanning across all submodules.
+
+## Testing
+
+### New Test Coverage
+
+Six new instrumented tests added to [`OAuthProviderTest`](../../sdk/authentication/src/androidTest/java/com/ibm/security/verifysdk/authentication/OAuthProviderTest.kt) covering `buildAuthorizeUri()`:
+
+| Test | What it guards |
+|---|---|
+| `buildAuthorizeUri_pathWithLeadingSlash_shouldNotProduceDoubleSlash` | Exact double-slash regression (leading `/` in `url.path`) |
+| `buildAuthorizeUri_deepPath_shouldNotProduceDoubleSlash` | Multi-segment paths (e.g. `/oauth2/authorize`) |
+| `buildAuthorizeUri_requiredQueryParams_shouldBePresent` | `response_type`, `client_id`, `redirect_uri`, `scope` always present |
+| `buildAuthorizeUri_withCodeChallenge_shouldIncludePkceParams` | PKCE `code_challenge` / `code_challenge_method` params |
+| `buildAuthorizeUri_withState_shouldIncludeStateParam` | `state` parameter is forwarded |
+| `buildAuthorizeUri_scopeWithoutOpenid_shouldAppendOpenid` | `openid` is automatically added when missing from scope |
+
+## Upgrade Notes
+
+No code changes are required when upgrading from 3.2.7 to 3.2.8. The URL fix is applied automatically inside `authorizeWithBrowser()`.
+
+## Known Issues
+
+None identified for this release.
+
+## Additional Notes
+
+- The double-slash fix affects all callers of `authorizeWithBrowser()` regardless of server hostname
+- The Netty update is recommended for all projects that transitively depend on Netty through Ktor or gRPC
+- The Mend SAST suppressions target well-understood Android patterns (deep links, WebViews, debug logging) that are intentional in this SDK and are not exploitable in the context they appear
+
+## Links
+
+- [GitHub Release](https://github.com/ibm-verify/verify-sdk-android/releases/tag/3.2.8)
+- [Repository](https://github.com/ibm-verify/verify-sdk-android)
+- [JitPack](https://jitpack.io/#ibm-verify/verify-sdk-android/3.2.8)
+
+## Support
+
+For issues, questions, or contributions, please visit:
+
+- [GitHub Issues](https://github.com/ibm-verify/verify-sdk-android/issues)
+- [Contributing Guide](../../CONTRIBUTING.md)
+
+---
+
+**Release Date:** July 2026
+**Version:** 3.2.8
+**Previous Version:** 3.2.7

--- a/sdk/adaptive/README.md
+++ b/sdk/adaptive/README.md
@@ -1,19 +1,19 @@
 # IBM Verify Adaptive SDK for Android
 
-**Version:** 3.2.0
+**Version:** 3.2.8
 **Package:** `com.ibm.security.verifysdk.adaptive`
 **Minimum API:** 29 (Android 10.0)
 **Target API:** 36 (Android 16)
 
 The adaptive component provides device assessment. Based on cloud risk policies, authentication and authorization challenges can be evaluated.
 
-## Recent Improvements (v3.2.0)
+## Recent Improvements (v3.2.8)
 
-- **Modern Lifecycle APIs**: Migrated from deprecated `LifecycleObserver` with `@OnLifecycleEvent` to `DefaultLifecycleObserver` for better type safety and compile-time checking
-- **Updated Dependencies**: Uses Core SDK 3.2.0 with improved networking and error handling
-- **Thread Safety**: Benefits from thread-safe NetworkHelper singleton
-- **Better Error Handling**: Structured exception handling from Core SDK
-- **Performance**: Lazy logging and optimized networking from Core SDK improvements
+- **Modern Lifecycle APIs**: Migrated from deprecated `LifecycleObserver` with `@OnLifecycleEvent` to `DefaultLifecycleObserver` for better type safety and compile-time checking.
+- **Updated Dependencies**: Uses Core SDK 3.2.8 with improved networking and error handling.
+- **Thread Safety**: Benefits from thread-safe `NetworkHelper` singleton.
+- **Better Error Handling**: Structured exception handling from Core SDK.
+- **Performance**: Lazy logging and optimized networking from Core SDK improvements.
 
 ## Getting started
 

--- a/sdk/authentication/README.md
+++ b/sdk/authentication/README.md
@@ -1,6 +1,6 @@
 # IBM Verify Authentication SDK for Android
 
-![SDK Version](https://img.shields.io/badge/IBM%20Security%20Verify%20Authentication%20SDK-3.2.0-blue.svg)
+![SDK Version](https://img.shields.io/badge/IBM%20Security%20Verify%20Authentication%20SDK-3.2.8-blue.svg)
 ![Android Version](https://img.shields.io/badge/Android-10+-green.svg)
 ![Android Version](https://img.shields.io/badge/Android%20API-29+-green.svg)
 
@@ -18,18 +18,21 @@ The IBM Verify Authentication SDK for Android is a comprehensive implementation 
 - **Browser-based Authentication** - Secure authentication via system browser using Android App Links
 - **Custom Tab Support** - Enhanced user experience with Chrome Custom Tabs
 
-## Recent Improvements (v3.2.0)
+## Recent Improvements (v3.2.8)
 
-- **Performance Optimizations**: Lazy logging reduces memory allocations in production builds
-- **Platform Independence**: Explicit UTF-8 charset usage in PKCE for reliable cross-platform behavior
-- **Improved DPoP**: Enhanced logging and error handling in DPoP proof generation
-- **Modern APIs**: Updated to use current coroutine continuation APIs
+- **Double-Slash URL Fix**: `authorizeWithBrowser()` no longer produces `https://host//path` URLs. `java.net.URL.getPath()` returns a leading `/`; `Uri.Builder.appendEncodedPath()` now strips it via `.trimStart('/')` before appending.
+- **`buildAuthorizeUri()` Helper**: URI construction logic extracted to `internal fun buildAuthorizeUri()` for independent testability without a live `ComponentActivity`.
+- **Authorization URI Test Coverage**: Six new instrumented regression tests in `OAuthProviderTest` covering the double-slash fix, deep paths, required query parameters, PKCE, state, and automatic `openid` scope injection.
+- **Performance Optimizations**: Lazy logging reduces memory allocations in production builds.
+- **Platform Independence**: Explicit UTF-8 charset usage in PKCE for reliable cross-platform behavior.
+- **Improved DPoP**: Enhanced logging and error handling in DPoP proof generation.
+- **Modern APIs**: Updated to use current coroutine continuation APIs.
 
 ## Getting started
 
 ### Prerequisites
 
-- Android API Level 23 (Marshmallow) or higher
+- Android API Level 29 (Android 10.0) or higher
 - IBM Verify tenant or IBM Verify Identity Access server
 - OAuth 2.0 / OIDC configured application
 
@@ -306,8 +309,8 @@ data class TokenInfo(
 
 ## Requirements
 
-- Android API Level 23 (Marshmallow) or higher
-- Kotlin 1.9 or higher
+- Android API Level 29 (Android 10.0) or higher
+- Kotlin 2.1.0 or higher
 - AndroidX libraries
 
 ## Dependencies

--- a/sdk/authentication/src/androidTest/java/com/ibm/security/verifysdk/authentication/OAuthProviderTest.kt
+++ b/sdk/authentication/src/androidTest/java/com/ibm/security/verifysdk/authentication/OAuthProviderTest.kt
@@ -650,6 +650,80 @@ internal class OAuthProviderTest {
         assertEquals("clientSecret", oAuthProvider.clientSecret)
     }
 
+    // -------------------------------------------------------------------------
+    // buildAuthorizeUri — double-slash regression tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun buildAuthorizeUri_pathWithLeadingSlash_shouldNotProduceDoubleSlash() {
+        // java.net.URL.getPath() always returns a leading '/' (e.g. "/authorize").
+        // Uri.Builder.appendEncodedPath() inserts a '/' separator, so naively passing
+        // url.path produced "https://host//authorize". trimStart('/') fixes this.
+        val url = URL("https://auth.example.com/authorize")
+        val uri = oAuthProvider.buildAuthorizeUri(url, "myapp://callback")
+        val uriString = uri.toString()
+
+        // indexOf("//", 7) skips the "https://" at position 0-7
+        assertTrue("URI must not contain '//' after the scheme", uriString.indexOf("//", 7) == -1)
+        assertTrue("URI must start with 'https://auth.example.com'", uriString.startsWith("https://auth.example.com"))
+        assertTrue("URI must contain '/authorize'", uriString.contains("/authorize"))
+    }
+
+    @Test
+    fun buildAuthorizeUri_deepPath_shouldNotProduceDoubleSlash() {
+        val url = URL("https://example.com/oauth2/authorize")
+        val uri = oAuthProvider.buildAuthorizeUri(url, "myapp://callback")
+        val uriString = uri.toString()
+
+        assertTrue("URI must not contain '//' after the scheme", uriString.indexOf("//", 7) == -1)
+        assertTrue("path must be '/oauth2/authorize'", uriString.contains("/oauth2/authorize"))
+    }
+
+    @Test
+    fun buildAuthorizeUri_requiredQueryParams_shouldBePresent() {
+        val url = URL("https://example.com/authorize")
+        val uri = oAuthProvider.buildAuthorizeUri(url, "myapp://callback")
+        val uriString = uri.toString()
+
+        assertTrue(uriString.contains("response_type=code"))
+        assertTrue(uriString.contains("client_id=clientId"))
+        assertTrue(uriString.contains("redirect_uri=myapp%3A%2F%2Fcallback"))
+        assertTrue(uriString.contains("scope=openid"))
+    }
+
+    @Test
+    fun buildAuthorizeUri_withCodeChallenge_shouldIncludePkceParams() {
+        val url = URL("https://example.com/authorize")
+        val uri = oAuthProvider.buildAuthorizeUri(
+            url,
+            "myapp://callback",
+            codeChallenge = "abc123",
+            method = CodeChallengeMethod.S256
+        )
+        val uriString = uri.toString()
+
+        assertTrue(uriString.contains("code_challenge=abc123"))
+        assertTrue(uriString.contains("code_challenge_method=S256"))
+    }
+
+    @Test
+    fun buildAuthorizeUri_withState_shouldIncludeStateParam() {
+        val url = URL("https://example.com/authorize")
+        val uri = oAuthProvider.buildAuthorizeUri(url, "myapp://callback", state = "randomState42")
+        assertTrue(uri.toString().contains("state=randomState42"))
+    }
+
+    @Test
+    fun buildAuthorizeUri_scopeWithoutOpenid_shouldAppendOpenid() {
+        val url = URL("https://example.com/authorize")
+        val uri = oAuthProvider.buildAuthorizeUri(url, "myapp://callback", scope = arrayOf("profile", "email"))
+        val uriString = uri.toString()
+
+        assertTrue("scope must contain 'openid'", uriString.contains("openid"))
+        assertTrue("scope must contain 'profile'", uriString.contains("profile"))
+        assertTrue("scope must contain 'email'", uriString.contains("email"))
+    }
+
     private val responseDiscoveryOk = """
         {
            "request_parameter_supported":true,

--- a/sdk/authentication/src/main/java/com/ibm/security/verifysdk/authentication/api/OAuthProvider.kt
+++ b/sdk/authentication/src/main/java/com/ibm/security/verifysdk/authentication/api/OAuthProvider.kt
@@ -177,33 +177,10 @@ class OAuthProvider(val clientId: String, val clientSecret: String? = null) : Ba
     ): Result<String> {
 
         return try {
-            val uriBuilder = Uri.Builder()
-            var myScope = scope ?: arrayOf("openid")
-
-            uriBuilder.scheme((url.protocol))
-                .encodedAuthority(url.authority)
-                .appendEncodedPath(url.path)
-                .appendQueryParameter("response_type", "code")
-                .appendQueryParameter("client_id", clientId)
-                .appendQueryParameter("redirect_uri", redirectUrl)
-
-            codeChallenge?.let {
-                uriBuilder.appendQueryParameter("code_challenge", codeChallenge)
-                uriBuilder.appendQueryParameter("code_challenge_method", method.name)
-            }
-
-            if (myScope.contains("openid").not()) {
-                myScope = myScope.plus("openid")
-            }
-            uriBuilder.appendQueryParameter("scope", myScope.joinToString(" "))
-
-            state?.let { uriBuilder.appendQueryParameter("state", it) }
-            additionalParameters.forEach {
-                uriBuilder.appendQueryParameter(it.key, it.value)
-            }
+            val authorizeUri = buildAuthorizeUri(url, redirectUrl, codeChallenge, method, scope, state)
 
             val intent = Intent(activity, AuthenticationActivity::class.java)
-            intent.putExtra("url", uriBuilder.build().toString())
+            intent.putExtra("url", authorizeUri.toString())
 
             suspendCancellableCoroutine { continuation ->
                 val getCode = activity.activityResultRegistry.register(
@@ -245,6 +222,48 @@ class OAuthProvider(val clientId: String, val clientSecret: String? = null) : Ba
         } catch (e: Throwable) {
             Result.failure(e)
         }
+    }
+
+    /**
+     * Builds the authorization [Uri] for the browser-based authorization code flow.
+     *
+     * Extracted from [authorizeWithBrowser] so that URL construction can be tested without
+     * requiring a live [ComponentActivity].
+     */
+    internal fun buildAuthorizeUri(
+        url: URL,
+        redirectUrl: String,
+        codeChallenge: String? = null,
+        method: CodeChallengeMethod = CodeChallengeMethod.PLAIN,
+        scope: Array<String>? = null,
+        state: String? = null
+    ): Uri {
+        val uriBuilder = Uri.Builder()
+        var myScope = scope ?: arrayOf("openid")
+
+        uriBuilder.scheme(url.protocol)
+            .encodedAuthority(url.authority)
+            .appendEncodedPath(url.path.trimStart('/'))
+            .appendQueryParameter("response_type", "code")
+            .appendQueryParameter("client_id", clientId)
+            .appendQueryParameter("redirect_uri", redirectUrl)
+
+        codeChallenge?.let {
+            uriBuilder.appendQueryParameter("code_challenge", codeChallenge)
+            uriBuilder.appendQueryParameter("code_challenge_method", method.name)
+        }
+
+        if (!myScope.contains("openid")) {
+            myScope = myScope.plus("openid")
+        }
+        uriBuilder.appendQueryParameter("scope", myScope.joinToString(" "))
+
+        state?.let { uriBuilder.appendQueryParameter("state", it) }
+        additionalParameters.forEach {
+            uriBuilder.appendQueryParameter(it.key, it.value)
+        }
+
+        return uriBuilder.build()
     }
 
     /**

--- a/sdk/core/README.md
+++ b/sdk/core/README.md
@@ -1,6 +1,6 @@
 # IBM Verify Core SDK for Android
 
-**Version:** 3.2.4
+**Version:** 3.2.8
 **Package:** `com.ibm.security.verifysdk.core`
 
 The IBM Verify Core SDK for Android provides common functionality and utilities used across all other SDK modules. It includes networking helpers, keystore management, logging extensions, and base exception classes.
@@ -43,16 +43,17 @@ val signature = KeystoreHelper.sign(alias = "my-key", data = dataToSign)
 - `VerifySdkException`: Base exception for all SDK errors
 - `AuthenticationException`: Authentication-specific errors with detailed error codes
 
-## Recent Improvements (v3.2.4)
+## Recent Improvements (v3.2.8)
 
-- **SSL Certificate Bypass Support**: Two-level security model for on-premise authenticators with self-signed certificates
-- **Enhanced Security Controls**: `allowInsecureSSL` flag and `createInsecureClient()` method with comprehensive documentation
-- **Certificate Transparency Support**: Optional CT verification via interceptor method (SDK best practice)
-- **Thread-Safe Networking**: Improved HttpClient initialization and lifecycle management
-- **Performance Optimizations**: Lazy logging to prevent string allocation when logging disabled
-- **Platform Independence**: Explicit StandardCharsets.UTF_8 usage for consistent behavior across platforms
-- **Improved Test Coverage**: Comprehensive test cases for KeystoreHelper and core utilities
-- **Better Error Handling**: Structured exception hierarchy with error chaining
+- **Netty Security Update**: `io.netty:netty-codec-http2`, `netty-codec-compression`, and `netty-handler-proxy` force-pinned to `4.2.15.Final` (from `4.2.5.Final`) in `build.gradle.kts`.
+- **SSL Certificate Bypass Support**: Two-level security model for on-premise authenticators with self-signed certificates.
+- **Enhanced Security Controls**: `allowInsecureSSL` flag and `createInsecureClient()` method with comprehensive documentation.
+- **Certificate Transparency Support**: Optional CT verification via interceptor method (SDK best practice).
+- **Thread-Safe Networking**: Improved HttpClient initialization and lifecycle management.
+- **Performance Optimizations**: Lazy logging to prevent string allocation when logging disabled.
+- **Platform Independence**: Explicit `StandardCharsets.UTF_8` usage for consistent behavior across platforms.
+- **Improved Test Coverage**: Comprehensive test cases for KeystoreHelper and core utilities.
+- **Better Error Handling**: Structured exception hierarchy with error chaining.
 
 ## Certificate Transparency
 
@@ -80,7 +81,7 @@ val client = NetworkHelper.getInstance
 - Easy to configure and test
 - Optional (disabled by default for backward compatibility)
 
-See `docs/CERTIFICATE_TRANSPARENCY_GUIDE.md` for detailed setup instructions.
+See [`docs/SSL_CERTIFICATE_BYPASS.md`](../../docs/SSL_CERTIFICATE_BYPASS.md) for detailed setup instructions.
 
 ## SSL Certificate Bypass (On-Premise Only)
 
@@ -105,7 +106,7 @@ val insecureClient = NetworkHelper.createInsecureClient()
 - Attempting to create insecure client when disabled throws `IllegalStateException`
 - All authenticators use standard SSL certificate validation by default
 
-See `docs/releases/3.2.4.md` for detailed documentation and security considerations.
+See [`docs/releases/3.2.8.md`](../../docs/releases/3.2.8.md) for detailed documentation and security considerations.
 
 ## Dependencies
 

--- a/sdk/fido2/README.md
+++ b/sdk/fido2/README.md
@@ -1,6 +1,6 @@
 # IBM Verify FIDO2™ SDK for Android
 
-**Version:** 3.2.0
+**Version:** 3.2.8
 **Package:** `com.ibm.security.verifysdk.fido2`
 
 The IBM Verify FIDO2™ SDK for Android is a native implementation of FIDO attestation and
@@ -26,12 +26,12 @@ This Verify FIDO2 SDK for Android is well suited for developers of pure native m
 that wish to provision only device-bound keys in scenarios where the use of synchronized passkeys
 for example is not suitable.
 
-## Recent Improvements (v3.2.0)
+## Recent Improvements (v3.2.8)
 
-- **Performance Optimizations**: COSEKey lazy initialization provides ~95% performance improvement for cached CBOR serialization
-- **Shared Resources**: CBORMapper instance shared across all COSEKey instances reduces memory footprint
-- **Modern APIs**: Updated biometric prompt to use current coroutine continuation APIs; migrated demo app from deprecated Ktor Base64 utilities to Kotlin stdlib `Base64.Default.decode()`
-- **Thread Safety**: Immutable map usage in COSEKey for better thread safety
+- **Performance Optimizations**: COSEKey lazy initialization provides ~95% performance improvement for cached CBOR serialization.
+- **Shared Resources**: CBORMapper instance shared across all COSEKey instances reduces memory footprint.
+- **Modern APIs**: Updated biometric prompt to use current coroutine continuation APIs; migrated demo app from deprecated Ktor Base64 utilities to Kotlin stdlib `Base64.Default.decode()`.
+- **Thread Safety**: Immutable map usage in COSEKey for better thread safety.
 
 ## Example
 
@@ -66,8 +66,8 @@ dependencyResolutionManagement {
 
 ```gradle
 dependencies {
-    implementation("com.ibm.security.verifysdk:core:3.0.1")
-    implementation("com.ibm.security.verifysdk:fido2:3.0.1")
+    implementation("com.ibm.security.verifysdk:core:3.2.8")
+    implementation("com.ibm.security.verifysdk:fido2:3.2.8")
     ...
 }
 ```

--- a/sdk/mfa/README.md
+++ b/sdk/mfa/README.md
@@ -1,6 +1,6 @@
 # IBM Verify SDK - MFA Module
 
-**Version:** 3.2.4
+**Version:** 3.2.8
 **Package:** `com.ibm.security.verifysdk.mfa`
 
 ## Overview
@@ -13,19 +13,19 @@ The MFA (Multi-Factor Authentication) module provides comprehensive support for 
 - **Biometric Authentication** - Unified biometric factor (fingerprint/face)
 - **User Presence** - Device-based authentication factors
 
-## Recent Improvements (v3.2.4)
+## Recent Improvements (v3.2.8)
 
-- **SSL Certificate Bypass**: Support for on-premise authenticators with self-signed certificates
-- **Authenticator ID Fix**: Corrected on-premise authenticator ID handling (tenant_id vs authenticator_id)
-- **Transaction Filtering**: Enhanced filtering logic using server's authenticator_id
-- **QR Code Options**: Support for parsing options field from QR codes
-- **Registration Attributes**: Fixed attribute naming to use snake_case (account_name, push_token)
-- **Enhanced Logging**: Comprehensive debug logging for transaction processing
-- **Performance Optimizations**: Lazy logging reduces memory allocations in production builds
-- **JSON Standardization**: Type-safe parsing with `kotlinx.serialization`
-- **Improved Test Coverage**: Comprehensive test cases for TokenPersistenceCallback and TransactionData
-- **Thread Safety**: Immutable service design ensures thread-safe operations
-- **Error Handling**: Structured exceptions with better error chaining
+- **SSL Certificate Bypass**: Support for on-premise authenticators with self-signed certificates.
+- **Authenticator ID Fix**: Corrected on-premise authenticator ID handling (`tenant_id` vs `authenticator_id`).
+- **Transaction Filtering**: Enhanced filtering logic using server's `authenticator_id`.
+- **QR Code Options**: Support for parsing options field from QR codes (e.g. `ignoreSslCerts=true`).
+- **Registration Attributes**: Fixed attribute naming to use snake_case (`account_name`, `push_token`).
+- **Enhanced Logging**: Comprehensive debug logging for transaction processing.
+- **Performance Optimizations**: Lazy logging reduces memory allocations in production builds.
+- **JSON Standardization**: Type-safe parsing with `kotlinx.serialization`.
+- **Improved Test Coverage**: Comprehensive test cases for `TokenPersistenceCallback` and `TransactionData`.
+- **Thread Safety**: Immutable service design ensures thread-safe operations.
+- **Error Handling**: Structured exceptions with better error chaining.
 
 ## Key Components
 
@@ -215,7 +215,7 @@ service.completeTransaction(
 
 ## Critical Concepts
 
-### 🔴 Token Persistence
+### Token Persistence
 
 **THE MOST IMPORTANT RULE:**
 > Tokens MUST be persisted to database BEFORE any API call that uses them.
@@ -365,12 +365,7 @@ fun `token refresh persists before returning success`() = runBlocking {
 
 ## Documentation
 
-- **Release Notes:** `/docs/releases/3.2.4.md`
-- **SDK Usage Guide:** `/docs/SDK-USAGE-GUIDE.md`
-- **Token Persistence Fix:** `/docs/token-persistence-critical-fix.md`
-- **Service Design Analysis:** `/docs/stateless-vs-stateful-service-analysis.md`
-- **Dependency Injection:** `/docs/network-helper-dependency-injection-analysis.md`
-- **JSON Standardization:** `/docs/json-library-standardization-analysis.md`
+- **Release Notes:** [`docs/releases/3.2.8.md`](../../docs/releases/3.2.8.md)
 
 ## Migration Notes
 
@@ -403,7 +398,7 @@ Debug logs currently use `log.error()` for visibility during development. These 
 
 ---
 
-**Module Version:** 3.2.4
-**Last Updated:** 2026-06-01
+**Module Version:** 3.2.8
+**Last Updated:** 2026-07-01
 **Minimum Android SDK:** 29
 **Target Android SDK:** 36

--- a/whitesource.config
+++ b/whitesource.config
@@ -1,1 +1,1 @@
-excludes=/tmp/containerbase/cache,**/.gradle/caches/modules-2,**/src/androidTest,**/src/test
+excludes=/tmp/containerbase/cache,**/.gradle/caches/modules-2,**/src/androidTest/**,**/src/test/**


### PR DESCRIPTION
## What does it do?

- **Fixes a double-slash URL bug in `OAuthProvider.authorizeWithBrowser()`** — the method was producing authorization URLs like `https://host//authorize`. The URI construction logic has been extracted into a new `internal fun buildAuthorizeUri()` helper and the leading slash is stripped from `url.path` before passing it to `Uri.Builder.appendEncodedPath()`.
- **Adds 6 regression tests** in `OAuthProviderTest` covering: the exact double-slash regression, multi-segment deep paths, required query parameters (`response_type`, `client_id`, `redirect_uri`, `scope`), PKCE params, `state` forwarding, and automatic `openid` scope injection.
- **Updates Netty** (`netty-codec-http2`, `netty-codec-compression`, `netty-handler-proxy`) from `4.2.5.Final` to `4.2.15.Final`.
- **Refines Mend SAST scan configuration** — excludes Android test Gradle configurations from scanning and suppresses known false-positive vulnerability types (`External URL Access`, `Intent Manipulation`, `WebView Usage`, `URL Redirection`, `Log Messages Information Leak`).
- **Aligns WhiteSource/Mend path exclusions** to glob-aware patterns (`**/src/androidTest/**`, `**/src/test/**`) so test sources are consistently excluded across all submodules.
- **Updates all SDK module READMEs** (authentication, core, mfa, fido2, adaptive) to version 3.2.8 with current improvements and dependency versions.
- **Cleans up historical release notes** (3.1.0–3.2.3) - fixes broken relative links.

## Motivation and Context

`java.net.URL.getPath()` always returns a path with a leading `/` (e.g. `/authorize`). When that value is passed directly to `Uri.Builder.appendEncodedPath()`, the builder inserts its own `/` separator, resulting in a double-slash in the final URL. This caused authorization requests to fail against servers that do not normalise double-slash paths.

The Netty update addresses upstream CVEs and bug fixes in the `4.2.x` series that are transitively pulled in via Ktor. The scan configuration changes reduce noise in Mend SAST reports by suppressing well-understood Android patterns (deep links, WebViews, debug logging) that are intentional in this SDK and are not exploitable in the contexts they appear.
